### PR TITLE
Fix Namespace in x509_to_cybox.py

### DIFF
--- a/scripts/x509_to_cybox/x509_to_cybox.py
+++ b/scripts/x509_to_cybox/x509_to_cybox.py
@@ -9,6 +9,7 @@ import sys
 import os
 import cybox
 from cybox.core import Observables, Observable, Object
+from cybox.utils.nsparser import Namespace
 
 #Supported X509 Keywords
 x509_keywords = ['Version', 'Serial Number', 'Signature Algorithm', 'Issuer', 'Not Before', 'Not After ', 'Subject',
@@ -33,8 +34,9 @@ def cert_to_cybox(cert_dict):
     properties_dict['certificate']['standard_extensions'] = {}
     properties_dict['certificate']['non_standard_extensions'] = {}
     properties_dict['certificate']['subject_public_key']['rsa_public_key'] = {}
-    x509_obj_dict = {'properties' : properties_dict}
-    observable_dict = {'id': cybox.utils.IDGenerator('x509_to_cybox').create_id(prefix="observable"), 'object' : x509_obj_dict}
+    x509_obj_dict = {'properties' : properties_dict} 
+    x509_to_cybox = Namespace("https://github.com/CybOXProject/Tools", "x509_to_cybox")
+    observable_dict = {'id': cybox.utils.IDGenerator(x509_to_cybox).create_id(prefix="observable"), 'object' : x509_obj_dict}
 
     for key, value in cert_dict.items():
         if key == 'Version' :


### PR DESCRIPTION
`cybox.utils.IDGenerator` expects a `Namespace` and not a `string` : 

```
$ python x509_to_cybox.py  -i example/example_certs.txt -o a.xml
Traceback (most recent call last):
  File "x509_to_cybox.py", line 287, in <module>
    main()    
  File "x509_to_cybox.py", line 272, in main
    observables_list.append(cert_to_cybox(cert_dict))
  File "x509_to_cybox.py", line 37, in cert_to_cybox
    observable_dict = {'id': cybox.utils.IDGenerator('x509_to_cybox').create_id(prefix="observable"), 'object' : x509_obj_dict}
  File "/home/yoyo/.virtualenvs/cybox-tools/src/python-cybox/cybox/utils/idgen.py", line 27, in __init__
    self.namespace = namespace
  File "/home/yoyo/.virtualenvs/cybox-tools/src/python-cybox/cybox/utils/idgen.py", line 38, in namespace
    raise ValueError("Must be a Namespace object")
ValueError: Must be a Namespace object
```
