### PR TITLE
Added debug conditional, flags for HTML control

### DIFF
--- a/scripts/cybox_to_html/cybox_to_html.xsl
+++ b/scripts/cybox_to_html/cybox_to_html.xsl
@@ -65,18 +65,18 @@ DEVELOPER NOTES
 
 
 
-<xsl:stylesheet 
+<xsl:stylesheet
     version="2.0"
     xmlns:cybox="http://cybox.mitre.org/cybox-2"
     xmlns:Common="http://cybox.mitre.org/common-2"
     xmlns:ArtifactObj="http://cybox.mitre.org/objects#ArtifactObject-2"
-    
-    xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
+
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:fn="http://www.w3.org/2005/xpath-functions"
 
-    xmlns:taxii="http://taxii.mitre.org/messages/taxii_xml_binding-1"
-    xmlns:stix="http://stix.mitre.org/stix-1"
+	xmlns:taxii="http://taxii.mitre.org/messages/taxii_xml_binding-1"
+	xmlns:stix="http://stix.mitre.org/stix-1"
     xmlns:SystemObj="http://cybox.mitre.org/objects#SystemObject-2"
     xmlns:FileObj="http://cybox.mitre.org/objects#FileObject-2"
     xmlns:ProcessObj="http://cybox.mitre.org/objects#ProcessObject-2"
@@ -103,7 +103,7 @@ DEVELOPER NOTES
     <!-- <CONFIG> -->
 
         <!-- debug will allow you to conditionally inject information in the XSLT routine -->
-        <xsl:variable name="debug" select="'true'"/>
+        <xsl:variable name="debug" select="'false'"/>
 
         <!-- include_html_body will inline all CSS and javascript as well as wrap the HTML node around the Cybox object HTML output -->
         <xsl:variable name="include_html_body" select="'true'"/>
@@ -111,8 +111,14 @@ DEVELOPER NOTES
         <!-- include_cybox_version_info will inject information and headers about the Cybox version -->
         <xsl:variable name="include_cybox_version_info" select="'true'"/>
 
+        <!-- include_cybox_version_info will inject information and headers about the Cybox version -->
+        <xsl:variable name="show_id_and_type_header_row" select="'true'"/>
+
         <!-- if ID tag not found, set your desired text -->
         <xsl:variable name="default_observable_missing_id" select="'Untitiled Observable ID'"/>
+
+        <!-- default display for observables and description "'none'" for collapsed and "''block'" for shown -->
+        <xsl:variable name="default_collapse" select="'block'"/>
 
         <!-- Raw Stix and Indicator Specific Configuration -->
 
@@ -120,7 +126,7 @@ DEVELOPER NOTES
             <xsl:variable name="show_indicator_package_title" select="'true'"/>
 
             <!-- if the below prefix variable ends in #, it will show an incrementer for multiple stix packages in your prefix. -->
-            <!-- if left blank, it will just show any applicable stix:Title's -->
+            <!-- if left blank, it will just show any applicable stix:Title's --> 
             <xsl:variable name="show_indicator_package_prefix" select="'Indicator Package #'"/>
 
             <!-- Next to the header, show a link (Show Long Description) which will collapse the description stix:STIX_Header/stix:Description -->
@@ -166,8 +172,11 @@ DEVELOPER NOTES
           <xsl:variable name="show_indicator_package_prefix" select="$show_indicator_package_prefix"/>
           <xsl:variable name="show_indicator_package_description" select="$show_indicator_package_description"/>
           <xsl:variable name="show_indicator_description" select="$show_indicator_description"/>
+          <xsl:variable name="default_collapse" select="$default_collapse"/>
+          <xsl:variable name="show_id_and_type_header_row" select="$show_id_and_type_header_row"/>
           <xsl:variable name="item" select="." />
           <xsl:variable name="previous" select=".." />
+          <xsl:variable name="show_long_text" select="if($default_collapse = 'none') then 'Show Long Description' else 'Hide Long Description'" />
           <div id="observablesspandiv" style="font-weight:bold; margin:5px; color:#BD9C8C;">
             <TABLE class="grid tablesorter" cellspacing="0">
                 <COLGROUP>
@@ -190,15 +199,15 @@ DEVELOPER NOTES
                                     </xsl:if>
                                     <xsl:value-of select="$previous/stix:STIX_Header/stix:Title"/>
                                     <xsl:if test="$show_indicator_package_description = 'true' and $previous/stix:STIX_Header/stix:Description">
-                                        <a style="font-size:18px; cursor:pointer; color:grey;">
+                                        <a style="font-size:18px; cursor:pointer; color:mintcream;">
                                             <xsl:attribute name="onclick"><xsl:value-of select="concat('showLongDescription(this, ', position(),');')"/></xsl:attribute>
-                                            (Show Long Description)
+                                            (<xsl:value-of select="$show_long_text"/>)
                                         </a>
                                     </xsl:if>
                                 </span>
 
                                 <xsl:if test="$show_indicator_package_description = 'true' and $previous/stix:STIX_Header/stix:Description">
-                                    <div style="font-size:13px; font-style: italic; display:none;">
+                                    <div style="font-size:13px; font-style: italic; display:{$default_collapse};">
                                         <xsl:attribute name="id"><xsl:value-of select="concat(position(),'_description')"/></xsl:attribute>
                                         <xsl:value-of select="$previous/stix:STIX_Header/stix:Description"/>
                                     </div>
@@ -206,14 +215,16 @@ DEVELOPER NOTES
                             </TH>
                         </TR>
                     </xsl:if>
-                    <TR>
-                        <TH class="header">
-                            ID
-                        </TH>
-                        <TH class="header">
-                            Type
-                        </TH>
-                    </TR>
+                    <xsl:if test="$show_id_and_type_header_row = 'true'">
+                        <TR>
+                            <TH class="header">
+                                ID
+                            </TH>
+                            <TH class="header">
+                                Type
+                            </TH>
+                        </TR>
+                    </xsl:if>
                 </THEAD>
                 <TBODY>
                     <xsl:for-each select="cybox:Observable | $item/stix:Indicator/indicator:Observable">
@@ -226,7 +237,7 @@ DEVELOPER NOTES
                             <xsl:when test="$parent/@xsi:type ='indicator:IndicatorType'">
                                 <xsl:if test="not(./preceding-sibling::node()/@id)">
                                     <TR style="width:100%;font-style:italic;">
-                                        <TD>
+                                        <TD style="background-color:#0088cc !important; color:white;">
 
                                             <strong>
                                                 <xsl:value-of select="$parent/@id"/>
@@ -236,18 +247,18 @@ DEVELOPER NOTES
                                             </strong>
 
                                             <xsl:if test="$show_indicator_description = 'true' and $parent/indicator:Description">
-                                                <div style="font-size:13px; font-style: italic; display:none;">
+                                                <div style="font-size:13px; font-style: italic; display:{$default_collapse};">
                                                     <xsl:attribute name="id"><xsl:value-of select="concat(position(),'_description')"/></xsl:attribute>
                                                     <xsl:value-of select="$previous/stix:STIX_Header/stix:Description"/>
                                                 </div>
 
-                                                <a style="cursor:pointer; color:grey;">
+                                                <a style="cursor:pointer; color:mintcream;">
                                                     <xsl:attribute name="onclick"><xsl:value-of select="concat('showLongIndicatorDescription(this, ', position(),');')"/></xsl:attribute>
-                                                    (Show Long Description)
+                                                    (<xsl:value-of select="$show_long_text"/>)
                                                 </a>
                                             </xsl:if>
                                         </TD>
-                                        <TD>
+                                        <TD style="background-color:#0088cc !important; color:white;">
                                             <xsl:if test="$parent/indicator:Type">
                                                 (<xsl:value-of select="$parent/indicator:Type"/>)
                                             </xsl:if>
@@ -260,10 +271,10 @@ DEVELOPER NOTES
 
 
                                 <xsl:if test="$show_indicator_description = 'true' and $parent/indicator:Description">
-                                    <TR  style="width:100%;font-style:italic;">
+                                    <TR style="width:100%;font-style:italic;">
                                         <TD colspan="2">
                                             <!--@todo, there is a bug with multiple indicator packages where the ID's will collide and descriptions wont collapse properly -->
-                                            <div style="font-size:13px; font-style: italic; display:none;">
+                                            <div style="font-size:13px; font-style: italic; display:{$default_collapse};">
                                                 <xsl:attribute name="id"><xsl:value-of select="concat(position(),'_ind_description')"/></xsl:attribute>
                                                 <xsl:value-of select="$parent/indicator:Description"/>
                                             </div>
@@ -904,6 +915,7 @@ function toggle(containerNode)
         <xsl:variable name="idStack" select="($idStack, fn:data(@id))" />
         <xsl:variable name="debug" select="$debug"/>
         <xsl:variable name="default_observable_missing_id" select="$default_observable_missing_id"/>
+        <xsl:variable name="default_collapse" select="$default_collapse"/>
         <xsl:variable name="contentVar" select="concat(count(ancestor::node()), '00000000', count(preceding::node()))"/>
         <xsl:variable name="imgVar" select="generate-id()"/>
         <xsl:variable name="parent" select="parent::node()"/>
@@ -912,11 +924,20 @@ function toggle(containerNode)
             <xsl:message>PROCESS OBSERVABLE current: <xsl:value-of select="@id"/>; stack: <xsl:value-of select="fn:string-join($idStack, ',')" /></xsl:message>
         </xsl:if>
 
+        <xsl:if test="$debug != 'true'">
+            <!-- for production output 1\n for each observable to ensure something is output -->
+            <xsl:message>1</xsl:message>
+        </xsl:if>
+
+        <xsl:variable name="plus_minus" select="if($default_collapse = 'none') then '+' else '-'" />
+
         <TR>
             <xsl:attribute name="class"><xsl:value-of select="$evenOrOdd" /></xsl:attribute>
             <TD>
                 <div id="fileObjAtt" class="collapsibleLabel" style="cursor: pointer;" onclick="toggleDiv('{$contentVar}','{$imgVar}','{$imgVar}-2')">
-                    <span id="{$imgVar}" style="font-weight:bold; margin:5px; color:#BD9C8C;">+</span>
+                    <span id="{$imgVar}" style="font-weight:bold; margin:5px; color:#BD9C8C;">
+                        <xsl:value-of select="$plus_minus"/>
+                    </span>
 
                     <xsl:choose>
                         <xsl:when test="@id">
@@ -930,7 +951,9 @@ function toggle(containerNode)
             </TD>
             <TD>
                 <div style="cursor: pointer;" onclick="toggleDiv('{$contentVar}','{$imgVar}','{$imgVar}-2')">
-                <span id="{$imgVar}-2" style="font-weight:bold; margin:5px; color:#BD9C8C;">+</span>
+                <span id="{$imgVar}-2" style="font-weight:bold; margin:5px; color:#BD9C8C;">
+                    <xsl:value-of select="$plus_minus"/>
+                </span>
                     <xsl:choose>
                         <xsl:when test="cybox:Observable_Composition">
                             Composition
@@ -953,9 +976,8 @@ function toggle(containerNode)
         </TR>
         <TR><xsl:attribute name="class"><xsl:value-of select="$evenOrOdd" /></xsl:attribute>
         <TD colspan="2">
-          <div id="{$contentVar}"  class="collapsibleContent" style="overflow:hidden; display:none; padding:0px 7px;">
+          <div id="{$contentVar}"  class="collapsibleContent" style="overflow:hidden; display:{$default_collapse}; padding:0px 7px;">
               <div><xsl:attribute name="id"><xsl:value-of select="@id"/></xsl:attribute>
-                  <div class="debug idStack">id stack: <xsl:value-of select="fn:string-join($idStack, ',')"/></div>
                   <xsl:if test="cybox:Title">
                     <br/>
                     <div id="section">
@@ -1131,7 +1153,6 @@ function toggle(containerNode)
             
         </xsl:element>
         <xsl:text> </xsl:text>
-        <span class="debug inlineOrByReferenceLabel">(inline object)</span>
         
     </xsl:template>
     
@@ -1208,7 +1229,6 @@ function toggle(containerNode)
         -->
         
         <xsl:text> </xsl:text>
-        <span class="debug inlineOrByReferenceLabel">(reference by idref)</span>
         
     </xsl:template>
 
@@ -1255,10 +1275,12 @@ function toggle(containerNode)
         <xsl:param name="targetObject" select="//*[@id = $targetId]" />
         <xsl:param name="relationshipOrAssociationType" />
         <xsl:param name="idStack" select="()" />
-        
+        <xsl:variable name="default_collapse" select="$default_collapse"/>
+        <xsl:variable name="collapse_class" select="if($default_collapse = 'none') then 'collapsed' else 'expanded'" />
+
         <xsl:choose>
             <xsl:when test="$targetObject and not(fn:exists($idStack[. = $targetId]))">
-                <div class="expandableContainer expandableSeparate collapsed">
+                <div class="expandableContainer expandableSeparate {$collapse_class}">
                     <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">
                         <xsl:call-template name="objectHeaderOnly">
                             <xsl:with-param name="targetObject" select="$targetObject" />
@@ -1369,8 +1391,6 @@ function toggle(containerNode)
                            <xsl:with-param name="id" select="@id"/>
                        </xsl:call-template>
                     </xsl:if>
-                    
-                    <div class="debug idStack">id stack: <xsl:value-of select="fn:string-join($idStack, ',')"/></div>
                     <!--
                       If this "object" is an object reference (an "idref link")
                       print out the link that will jump to the original object.
@@ -1456,7 +1476,6 @@ function toggle(containerNode)
         <div class="container action">
             <div class="heading action">ACTION <xsl:value-of select="cybox:Type/text()" /> (xsi type: <xsl:value-of select="cybox:Type/@xsi:type" />)</div>
             <div class="contents action">
-                <div class="debug idStack">id stack: <xsl:value-of select="fn:string-join($idStack, ',')"/></div>
                 <xsl:apply-templates select="cybox:Associated_Objects">
                     <xsl:with-param name="idStack" select="$idStack" />
                 </xsl:apply-templates>
@@ -1545,9 +1564,13 @@ function toggle(containerNode)
          binary base64 data)
     -->
     <xsl:template match="text()" mode="cyboxProperties">
+
+        <xsl:variable name="default_collapse" select="$default_collapse"/>
+        <xsl:variable name="collapse_class" select="if($default_collapse = 'none') then 'collapsed' else 'expanded'" />
+
         <xsl:choose>
             <xsl:when test="string-length() gt 200">
-                <div class="longText expandableContainer expandableToggle expandableContents collapsed expandableSame" onclick="toggle(this)"><xsl:value-of select="fn:data(.)" /></div>
+                <div class="longText expandableContainer expandableToggle expandableContents {$collapse_class} expandableSame" onclick="toggle(this)"><xsl:value-of select="fn:data(.)" /></div>
             </xsl:when>
             <xsl:otherwise>
                 <xsl:value-of select="fn:data(.)" />

--- a/scripts/cybox_to_html/working_set_examples/CybOX_Iran-Oil_Dynamic-Taxii-Stix-Example.html
+++ b/scripts/cybox_to_html/working_set_examples/CybOX_Iran-Oil_Dynamic-Taxii-Stix-Example.html
@@ -1,0 +1,5205 @@
+<html xmlns:stix="http://stix.mitre.org/stix-1" xmlns:LibraryObj="http://cybox.mitre.org/objects#LibraryObject-2" xmlns:WinProcessObj="http://cybox.mitre.org/objects#WinProcessObject-2" xmlns:SystemObj="http://cybox.mitre.org/objects#SystemObject-2" xmlns:EmailMessageObj="http://cybox.mitre.org/objects#EmailMessageObject-2" xmlns:FileObj="http://cybox.mitre.org/objects#FileObject-2" xmlns:WinHandleObj="http://cybox.mitre.org/objects#WinHandleObject-2" xmlns:ProcessObj="http://cybox.mitre.org/objects#ProcessObject-2" xmlns:WinMutexObj="http://cybox.mitre.org/objects#WinMutexObject-2" xmlns:PipeObj="http://cybox.mitre.org/objects#PipeObject-2" xmlns:WinServiceObj="http://cybox.mitre.org/objects#WinServiceObject-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:PortObj="http://cybox.mitre.org/objects#PortObject-2" xmlns:WinRegistryKeyObj="http://cybox.mitre.org/objects#WinRegistryKeyObject-2" xmlns:cybox="http://cybox.mitre.org/cybox-2" xmlns:AddressObj="http://cybox.mitre.org/objects#AddressObject-2" xmlns:WinPipeObj="http://cybox.mitre.org/objects#WinPipeObject-2" xmlns:Common="http://cybox.mitre.org/common-2" xmlns:SocketObj="http://cybox.mitre.org/objects#SocketObject-2" xmlns:WinDriverObj="http://cybox.mitre.org/objects#WinDriverObject-2" xmlns:ArtifactObj="http://cybox.mitre.org/objects#ArtifactObject-2" xmlns:MutexObj="http://cybox.mitre.org/objects#MutexObject-2" xmlns:WinFileObj="http://cybox.mitre.org/objects#WinFileObject-2" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:MemoryObj="http://cybox.mitre.org/objects#MemoryObject-2" xmlns:WinExecutableFileObj="http://cybox.mitre.org/objects#WinExecutableFileObject-2" xmlns:taxii="http://taxii.mitre.org/messages/taxii_xml_binding-1" xmlns:URIObj="http://cybox.mitre.org/objects#URIObject-2" xmlns:indicator="http://stix.mitre.org/Indicator-2">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+      <title>CybOX Output</title>
+      <meta http-equiv="X-UA-Compatible" content="IE=edge"><style type="text/css">
+
+                    body
+                    {
+                      font-family: Arial,Helvetica,sans-serif;
+                    }
+                    /* define table skin */
+                    table.grid {
+                    margin: 0px;
+                    margin-left: 25px;
+                    padding: 0;
+                    border-collapse: separate;
+                    border-spacing: 0;
+                    width: 100%;
+                    border-style:solid;
+                    border-width:1px;
+                    }
+
+                    table.grid thead, table.grid .collapsible {
+                    background-color: #c7c3bb;
+                    }
+
+                    table.grid th {
+                    color: #565770;
+                    padding: 4px 16px 4px 0;
+                    padding-left: 10px;
+                    font-weight: bold;
+                    text-align: left;
+                    }
+
+                    table.grid td {
+                    color: #565770;
+                    padding: 4px 6px;
+                    }
+
+                    table.grid tr.even {
+                    background-color: #EDEDE8;
+                    }
+
+                    body {
+                    }
+                    #wrapper {
+                    margin: 0 auto;
+                    width: 80%;
+                    }
+                    #header {
+                    color: #333;
+                    padding: 10px;
+                    margin: 10px 0px 5px 0px;
+                    }
+                    #content {
+                    width: 100%;
+                    color: #333;
+                    border: 2px solid #ccc;
+                    background: #FFFFFF;
+                    margin: 0px 0px 5px 0px;
+                    padding: 10px;
+                    font-size: 11px;
+                    color: #039;
+                    }
+
+                    #hor-minimalist-a
+                    {
+                      font-family: "Lucida Sans Unicode", "Lucida Grande", Sans-Serif;
+                      font-size: 12px;
+                    }
+                    #hor-minimalist-a > thead > tr > th
+                    {
+                      border-bottom: 2px solid #6678b1;
+                      text-align: left;
+                    }
+                    .one-column-emphasis
+                    {
+                    margin: 0px;
+                    text-align: left;
+                    width: 100%;
+                    border-spacing: 0;
+                    }
+                    .one-column-emphasis > tbody > tr > td
+                    {
+                    padding: 5px 10px;
+                    color: #200;
+                    }
+                    .oce-first
+                    {
+                    background: #d0dafd;
+                    border-right: 10px solid transparent;
+                    border-left: 10px solid transparent;
+                    }
+                    .oce-first-obs
+                    {
+                    background: #EFF8F4;
+                    border-right: 10px solid black;
+                    }
+                    .oce-first-obscomp-or
+                    {
+                    background: #E9EEF4;
+                    border-right: 10px solid transparent;
+                    }
+                    .oce-first-obscomp-and
+                    {
+                    background: #F2F4E9;
+                    border-right: 10px solid transparent;
+                    }
+                    .oce-first-inner
+                    {
+                    background: #EFF8F4;
+                    border-right: 10px solid transparent;
+                    border-left: 10px solid transparent;
+                    }
+                    .oce-first-inner-inner
+                    {
+                    background: #E5F4EE;
+                    border-right: 10px solid transparent;
+                    border-left: 10px solid transparent;
+                    }
+                    .oce-first-inner-inner-inner
+                    {
+                    background: #DBEFE6;
+                    border-right: 10px solid transparent;
+                    border-left: 10px solid transparent;
+                    }
+                    .oce-first-inner-inner-inner-inner
+                    {
+                    background: #D0EAE0;
+                    border-right: 10px solid transparent;
+                    border-left: 10px solid transparent;
+                    }
+                    .oce-first-inner-inner-inner-inner-inner
+                    {
+                    background: #B7D1C6;
+                    border-right: 10px solid transparent;
+                    border-left: 10px solid transparent;
+                    }
+                    #container {
+                    color: #333;
+                    border: 1px solid #ccc;
+                    background: #FFFFFF;
+                    margin: 0px 0px 10px 0px;
+                    padding: 10px;
+                    }
+                    #section {
+                    color: #333;
+                    background: #FFFFFF;
+                    margin: 0px 0px 5px 0px;
+                    }
+                    #object_label_div div {
+                    }
+                    #object_type_label {
+                    width:200px;
+                    background: #e8edff;
+                    border-top: 1px solid #ccc;
+                    border-left: 1px solid #ccc;
+                    border-right: 5px solid #ccc;
+                    padding: 1px;
+                    }
+                    #defined_object_type_label {
+                    width:400px;
+                    background: #E9F3CF;
+                    border-top: 1px solid #ccc;
+                    border-left: 1px solid #ccc;
+                    border-right: 1px solid #ccc;
+                    padding: 1px;
+                    }
+                    #associated_object_label {
+                    font-size: 12px;
+                    margin-bottom: 2px;
+                    }
+                    .heading,
+                    .eventTypeHeading
+                    {
+                      margin-bottom: 0.5em;
+                      font-weight: bold;
+                    }
+                    .contents,
+                    .eventDescription
+                    {
+                      margin-top: 0.5em;
+                      margin-bottom: 0.5em;
+                    }
+                    .container
+                    {
+                      margin-left: 1em;
+                      padding-left: 0.5em;
+                    }
+                    .eventDescription,
+                    .description
+                    {
+                      font-style: italic!important;
+                      margin-top: 0.5em;
+                      margin-bottom: 0.5em;
+                    }
+                    .description::before
+                    {
+                      content: "description: "
+                    }
+                    .emailDiv
+                    {
+                      display: block!important;
+                    }
+                    .relatedTarget
+                    {
+                    animation: targetHighlightAnimation 0.2s 10;
+                    animation-direction: alternate;
+                    -webkit-animation: targetHighlightAnimation 0.2s;
+                    -webkit-animation-direction: alternate;
+                    -webkit-animation-iteration-count: 10;
+                    /*
+                    border-style: solid;
+                    border-witdh: thin;
+                    border=color: hsla(360, 100%, 50%, 1);
+                    */
+                    }
+                    @keyframes targetHighlightAnimation
+                    {
+                    0% {background: hsla(360, 100%, 50%, .3); }
+                    100% {background: hsla(360, 100%, 50%, .7); }
+                    }
+                    @-webkit-keyframes targetHighlightAnimation
+                    {
+                    0% {background: hsla(360, 100%, 50%, .3); }
+                    100% {background: hsla(360, 100%, 50%, .7); }
+                    }
+
+                    .highlightTargetLink
+                    {
+                    color: blue;
+                    text-decoration: underline;
+                    }
+
+                    table.compositionTableOperator > tbody > tr > td
+                    {
+                      padding: 0.5em;
+                    }
+                    table.compositionTableOperand > tbody > tr > td
+                    {
+                      padding: 0;
+                    }
+                    table.compositionTableOperator > tbody > tr > td,
+                    table.compositionTableOperand > tbody > tr > td
+                    {
+                      border: none;
+                      padding: 0.5em;
+                    }
+                    .compositionTable,
+                    .compositionTableOperator,
+                    .compositionTableOperand
+                    {
+                      border-collapse: collapse;
+                      padding: 0!important;
+                      border: none;
+                    }
+                    td.compositionTable,
+                    td.compositionTableOperator,
+                    td.compositionTableOperand
+                    {
+                      padding: 0!important;
+                      border: none;
+                    }
+                    .compositionTableOperand
+                    {
+                      padding: 0.5em;
+                    }
+                    .compositionTableOperand > tbody > tr > td > div
+                    {
+                      background-color: lightcyan;
+                      padding: 0.7em;
+                    }
+
+                    .table-display dt
+                    {
+                    clear: left;
+                    float: left;
+                    width: 200px;
+                    margin: 0;
+                    padding: 5px;
+                    border-top: 1px solid #999;
+                    font-weight: bold;
+                    }
+
+                    .table-display dd
+                    {
+                    float: left;
+                    width: 300px;
+                    margin: 0;
+                    padding: 5px;
+                    border-top: 1px solid #999;
+                    }
+
+                    .verbatim
+                    {
+                      white-space: pre-line;
+                      margin-left: 1em;
+                    }
+                    table
+                    {
+                      empty-cells: show;
+                    }
+
+                    .externalLinkWarning
+                    {
+                      font-weight: bold;
+                      color: red;
+                    }
+
+                    .inlineOrByReferenceLabel
+                    {
+                      font-style: italic!important;
+                      color: lightgray;
+                    }
+
+                    .contents
+                    {
+                      padding-left: 1em;
+                    }
+
+                    .cyboxPropertiesValue
+                    {
+                      font-weight: normal;
+                    }
+
+                    .cyboxPropertiesConstraints
+                    {
+                      font-weight: normal;
+                      font-style: italic!important;
+                      color: red;
+                    }
+
+                    .cyboxPropertiesConstraints .objectReference
+                    {
+                      color: black;
+                    }
+
+                    .objectReference
+                    {
+                      margin-left: 1em;
+                    }
+
+                    .expandableContainer.collapsed > .expandableToggle::before,
+                    .expandableContainer.collapsed.expandableToggle::before
+                    {
+                      content: "+";
+                    }
+                    .expandableContainer.expanded > .expandableToggle::before,
+                    .expandableContainer.expanded.expandableToggle::before
+                    {
+                      content: "-";
+                    }
+                    .expandableContainer > .expandableToggle::before,
+                    .expandableContainer.expandableToggle::before,
+                    .nonexpandableContainer::before
+                    {
+                      color: goldenrod;
+                      display: inline-block;
+                      width: 1.5em;
+                    }
+                    .nonexpandableContainer::before
+                    {
+                      content: "";
+                    }
+
+                    .expandableToggle
+                    {
+                      cursor: pointer;
+                    }
+                    .expandableContainer > .expandableContents
+                    {
+                      background-color: #A8CBDE;
+                      padding: 1em;
+                    }
+
+                    .expandableSeparate.expandableContainer.collapsed > .expandableContents
+                    {
+                      display: none;
+                    }
+
+                    .longText
+                    {
+                       width: 60em;
+                    }
+                    .expandableSame.expandableContainer.collapsed
+                    {
+                      overflow: hidden;
+                      height: 1em;
+                    }
+                    .expandableSame.expandableContainer.expanded
+                    {
+                        word-wrap: break-word;
+                    }
+
+                    .debug
+                    {
+                      display: none;
+                    }
+                </style><script type="text/javascript">
+                    
+                    //Collapse functionality
+                    function toggleDiv(divid, spanID, span2)
+                    {
+                      if(document.getElementById(divid).style.display == 'none')
+                      {
+                        document.getElementById(divid).style.display = 'block';
+                        if(spanID)
+                        {
+                          document.getElementById(spanID).innerText = "-";
+                        }
+                        if(span2)
+                        {
+                          document.getElementById(span2).innerText = "-";
+                        }
+                      } // end of if-then
+                      else
+                      {
+                        document.getElementById(divid).style.display = 'none';
+                        if(spanID)
+                        {
+                          document.getElementById(spanID).innerText = "+";
+                        }
+                        if(span2)
+                        {
+                          document.getElementById(span2).innerText = "+";
+                        }
+                      } // end of else
+                    } // end of function toggleDiv()
+                    
+                </script><script type="text/javascript">
+
+var currentTarget = null;
+var previousTarget = null;
+
+/*
+  when a user clicks on a idref link, find, scroll to, and highlight the
+  target element.  this is usually an object, event, observable, related
+  object, or associated object.
+
+  the highlighting is done via css transitions.
+*/
+function highlightTarget(targetId)
+{
+    var targetElement = document.getElementById(targetId);
+    if (targetElement == null)
+    {
+      alert("target not in present document");
+      return;
+    }
+    targetElement.setAttribute("class", "");
+    findAndExpandTarget(targetElement);
+    targetElement.scrollIntoView(false);
+    targetElement.setAttribute("class", "relatedTarget");
+}
+
+/*
+  When a user clicks on an indicator long description
+*/
+
+function showLongDescription(obj, targetId)
+{
+    toggleText(obj, targetId,'_description');
+}
+
+function showLongIndicatorDescription(obj, targetId)
+{
+    toggleText(obj, targetId,'_ind_description');
+}
+
+function toggleText(obj, targetId, id_convention)
+{
+    var targetElement = document.getElementById(targetId + id_convention);
+    if (targetElement == null)
+    {
+        alert("target not in present document");
+        return;
+    }
+    if(targetElement.style.display == 'block')
+    {
+        targetElement.style.display = 'none';
+        obj.innerHTML = '(Show Long Description)';
+    }
+    else
+    {
+        targetElement.style.display = 'block';
+        obj.innerHTML = '(Hide Long Description)';
+    }
+}
+
+/*
+  When a user clicks on an idref link, this function will find that referenced
+  element and expand the parent Observable table row (if it's collapsed).
+*/
+function findAndExpandTarget(targetElement)
+{
+    var currentAncestor = targetElement.parentNode;
+    var isFound = false;
+    while (currentAncestor != null && !isFound)
+    {
+        isFound = currentAncestor.classList.contains("collapsibleContent");
+        if (!isFound) { currentAncestor = currentAncestor.parentNode; }
+    }
+
+    if (isFound)
+    {
+        //var collapsibleLabel = currentAncestor.previousSibling;
+        currentAncestor.style.display = 'block';
+    }
+}
+
+
+function toggle(containerNode)
+{
+  console.log("starting toggle");
+  //var parent = currentNode.parentNode;
+
+  containerNode.classList.toggle("collapsed");
+  containerNode.classList.toggle("expanded");
+
+  console.log("finished toggle");
+}
+
+</script></head>
+   <body>
+      <div id="wrapper">
+         <div id="observablesspandiv" style="font-weight:bold; margin:5px; color:#BD9C8C;">
+            <TABLE class="grid tablesorter" cellspacing="0">
+               <COLGROUP>
+                  <COL width="90%">
+                  <COL width="10%">
+               </COLGROUP>
+               <THEAD>
+                  <TR>
+                     <TH colspan="2" class="header"><span style="font-size: 24px;">Iran-Oil Stix Package<a style="font-size:18px; cursor:pointer; color:grey;" onclick="showLongDescription(this, 1);">
+                              (Show Long Description)
+                              </a></span><div style="font-size:13px; font-style: italic; display:none;" id="1_description">This collection of observables were observed as part of the widespread "Iran-Oil"
+                           (among many other names used) attack campaign in March 2012
+                        </div>
+                     </TH>
+                  </TR>
+                  <TR>
+                     <TH class="header">
+                        ID
+                        
+                     </TH>
+                     <TH class="header">
+                        Type
+                        
+                     </TH>
+                  </TR>
+               </THEAD>
+               <TBODY>
+                  <TR style="width:100%;font-style:italic;">
+                     <TD><strong>TEST:indicator-f205f08f-818b-4670-8491-45fad9e37ee4</strong><div style="font-size:13px; font-style: italic; display:none;" id="1_description">This collection of observables were observed as part of the widespread "Iran-Oil"
+                           (among many other names used) attack campaign in March 2012
+                        </div><a style="cursor:pointer; color:grey;" onclick="showLongIndicatorDescription(this, 1);">
+                           (Show Long Description)
+                           </a></TD>
+                     <TD>
+                        (Malicious E-mail)
+                        
+                     </TD>
+                  </TR>
+                  <TR style="width:100%;font-style:italic;">
+                     <TD colspan="2">
+                        <div style="font-size:13px; font-style: italic; display:none;" id="1_ind_description">Test Email Description!! Test Email Description!! Test Email Description!! Test Email
+                           Description!! Test Email Description!! Test Email Description!! Test Email Description!!
+                           Test Email Description!! Test Email Description!! Test Email Description!! Test Email
+                           Description!! Test Email Description!! Test Email Description!! Test Email Description!!
+                           Test Email Description!! Test Email Description!! Test Email Description!! Test Email
+                           Description!! Test Email Description!! Test Email Description!! Test Email Description!!
+                           Test Email Description!! Test Email Description!! Test Email Description!! Test Email
+                           Description!! 
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR class="">
+                     <TD>
+                        <div id="fileObjAtt" class="collapsibleLabel" style="cursor: pointer;" onclick="toggleDiv('70000000061','d1e68','d1e68-2')"><span id="d1e68" style="font-weight:bold; margin:5px; color:#BD9C8C;">+</span>example:Observable-1a937ec2-90ab-4e0e-a37c-db9b2e66a58e
+                        </div>
+                     </TD>
+                     <TD>
+                        <div style="cursor: pointer;" onclick="toggleDiv('70000000061','d1e68','d1e68-2')"><span id="d1e68-2" style="font-weight:bold; margin:5px; color:#BD9C8C;">+</span>
+                           Event
+                           
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR class="">
+                     <TD colspan="2">
+                        <div id="70000000061" class="collapsibleContent" style="overflow:hidden; display:none; padding:0px 7px;">
+                           <div id="example:Observable-1a937ec2-90ab-4e0e-a37c-db9b2e66a58e">
+                              <div class="debug idStack">id stack: example:Observable-1a937ec2-90ab-4e0e-a37c-db9b2e66a58e</div><br><div id="section">
+                                 <table class="one-column-emphasis">
+                                    <colgroup>
+                                       <col class="oce-first-obs">
+                                    </colgroup>
+                                    <tbody>
+                                       <tr>
+                                          <td>
+                                             <div class="container eventContainer event">
+                                                <div class="heading eventHeading event">
+                                                   <div class="debug idStack">id stack: example:Observable-1a937ec2-90ab-4e0e-a37c-db9b2e66a58e</div>
+                                                </div>
+                                                <div class="contents eventContents event">
+                                                   <div class="eventDescription description">
+                                                      description: Receive "Iran-Oil" attack campaign email message.
+                                                   </div>
+                                                   <div class="container">
+                                                      <div class="heading actions">Actions</div>
+                                                      <div class="contents actions">
+                                                         <div class="container action">
+                                                            <div class="heading action">ACTION Receive (xsi type: cyboxVocabs:ActionTypeVocab-1.0)</div>
+                                                            <div class="contents action">
+                                                               <div class="debug idStack">id stack: example:Observable-1a937ec2-90ab-4e0e-a37c-db9b2e66a58e</div>
+                                                               <div class="container associatedObjects">
+                                                                  <div class="heading associatedObjects">Associated Objects
+                                                                     
+                                                                  </div>
+                                                                  <div class="contents associatedObjects">
+                                                                     <div class="container associatedObjectContainer associatedObject" id="example:Object-51359587-f201-4383-b032-5a64522fcd7d">
+                                                                        <div class="heading associatedObjectHeading associatedObject">Returned ○  EmailMessageObjectType ○ <span class="inlineObject">example:Object-51359587-f201-4383-b032-5a64522fcd7d</span> <span class="debug inlineOrByReferenceLabel">(inline object)</span><div class="debug idStack">id stack: example:Observable-1a937ec2-90ab-4e0e-a37c-db9b2e66a58e,example:Object-51359587-f201-4383-b032-5a64522fcd7d</div>
+                                                                        </div>
+                                                                        <div class="contents associatedObjectContents associatedObject">
+                                                                           <div>
+                                                                              <fieldset>
+                                                                                 <legend>
+                                                                                    cybox properties
+                                                                                    (type: EmailMessageObjectType)
+                                                                                    
+                                                                                 </legend>
+                                                                                 <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                    <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Header</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                          
+                                                                                          
+                                                                                          
+                                                                                          
+                                                                                          </span><div class="cyboxPropertiesLink"></div>
+                                                                                    </div>
+                                                                                    <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                       <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                          <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">To</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                                
+                                                                                                </span><div class="cyboxPropertiesLink"></div>
+                                                                                          </div>
+                                                                                          <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Recipient</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [category=e-mail]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                                      
+                                                                                                      </span><div class="cyboxPropertiesLink"></div>
+                                                                                                </div>
+                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                                   <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                      <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Address_Value</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">william.abnett@gmail.com</span><div class="cyboxPropertiesLink"></div>
+                                                                                                      </div>
+                                                                                                      <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                   </div>
+                                                                                                </div>
+                                                                                             </div>
+                                                                                          </div>
+                                                                                       </div>
+                                                                                       <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                          <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">From</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [category=e-mail]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                                
+                                                                                                </span><div class="cyboxPropertiesLink"></div>
+                                                                                          </div>
+                                                                                          <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Address_Value</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">wmorrison89@gmail.com</span><div class="cyboxPropertiesLink"></div>
+                                                                                                </div>
+                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                             </div>
+                                                                                          </div>
+                                                                                       </div>
+                                                                                       <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                          <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Subject</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">Iran's Oil and Nuclear Situation</span><div class="cyboxPropertiesLink"></div>
+                                                                                          </div>
+                                                                                          <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                       </div>
+                                                                                       <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                          <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Date</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [datatype=dateTime]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">2012-03-02T07:42:24Z</span><div class="cyboxPropertiesLink"></div>
+                                                                                          </div>
+                                                                                          <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                       </div>
+                                                                                    </div>
+                                                                                 </div>
+                                                                                 <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                    <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Raw_Header</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [datatype=string]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                          <div class="verbatim">
+                                                                                             Return-Path: &lt;wmorrison89@gmail.com&gt;
+                                                                                             Received-SPF: pass (google.com: domain of wmorrison89@gmail.com designates
+                                                                                             10.236.185.4 as permitted sender) client-ip=10.236.185.4;
+                                                                                             Authentication-Results: mr.google.com; spf=pass (google.com: domain of
+                                                                                             wmorrison89@gmail.com designates 10.236.185.4 as permitted sender)
+                                                                                             smtp.mail=wmorrison89@gmail.com; dkim=pass header.i=wmorrison89@gmail.com
+                                                                                             Received: from mr.google.com ([10.236.185.4]) by 10.236.185.4 with SMTP
+                                                                                             id t4mr5301660yhm.129.1330692273662 (num_hops = 1); Fri, 02 Mar 2012
+                                                                                             04:44:33 -0800 (PST)
+                                                                                             MIME-Version: 1.0
+                                                                                             Received: by 10.236.185.4 with SMTP id t4mr4236541yhm.129.1330692265380;
+                                                                                             Fri,
+                                                                                             02 Mar 2012 04:44:25 -0800 (PST)
+                                                                                             Received: by 10.147.35.14 with HTTP; Fri, 2 Mar 2012 04:44:24 -0800 (PST)
+                                                                                             In-Reply-To:
+                                                                                             &lt;CADY6HTa-jmaqmtVyyT-nLz6reztNjcs-617wL4bt9YBOGu+h4w@mail.gmail.com&gt;
+                                                                                             References:
+                                                                                             &lt;CADY6HTa-jmaqmtVyyT-nLz6reztNjcs-617wL4bt9YBOGu+h4w@mail.gmail.com&gt;
+                                                                                             Date: Fri, 2 Mar 2012 07:44:24 -0500
+                                                                                             Message-ID:
+                                                                                             &lt;CADY6HTZ6oopY5v6WkYU81YcSQw3X124CK_Fx4jhnhUiU3Y9z6A@mail.gmail.com&gt;
+                                                                                             Subject: Iran's Oil and Nuclear Situation
+                                                                                             From: william abnett &lt;wmorrison89@gmail.com&gt;
+                                                                                             To: william.abnett &lt;william.abnett@gmail.com&gt;
+                                                                                             Content-Type: multipart/mixed; boundary="20cf303f67fac8928804ba41efd5"
+                                                                                             
+                                                                                          </div></span><div class="cyboxPropertiesLink"></div>
+                                                                                    </div>
+                                                                                    <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                 </div>
+                                                                                 <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                    <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Attachments</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                          
+                                                                                          </span><div class="cyboxPropertiesLink"></div>
+                                                                                    </div>
+                                                                                    <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                       <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                          <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">File</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue"></span><div class="cyboxPropertiesLink">
+                                                                                                <div class="objectReference nonexpandableContainer"> <span class="externalLinkWarning">[external]</span>  ○ cybox:guid-49d31c13-8d7b-4528-b8d6-ce8ed0d43ad7 <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                             </div>
+                                                                                          </div>
+                                                                                          <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                       </div>
+                                                                                    </div>
+                                                                                 </div>
+                                                                              </fieldset>
+                                                                           </div>
+                                                                        </div>
+                                                                     </div>
+                                                                  </div>
+                                                               </div>
+                                                            </div>
+                                                         </div>
+                                                      </div>
+                                                   </div>
+                                                   <div></div>
+                                                </div>
+                                             </div>
+                                          </td>
+                                       </tr>
+                                    </tbody>
+                                 </table>
+                              </div>
+                           </div>
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR style="width:100%;font-style:italic;">
+                     <TD colspan="2">
+                        <div style="font-size:13px; font-style: italic; display:none;" id="2_ind_description">Test Email Description!! Test Email Description!! Test Email Description!! Test Email
+                           Description!! Test Email Description!! Test Email Description!! Test Email Description!!
+                           Test Email Description!! Test Email Description!! Test Email Description!! Test Email
+                           Description!! Test Email Description!! Test Email Description!! Test Email Description!!
+                           Test Email Description!! Test Email Description!! Test Email Description!! Test Email
+                           Description!! Test Email Description!! Test Email Description!! Test Email Description!!
+                           Test Email Description!! Test Email Description!! Test Email Description!! Test Email
+                           Description!! 
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR class="">
+                     <TD>
+                        <div id="fileObjAtt" class="collapsibleLabel" style="cursor: pointer;" onclick="toggleDiv('700000000128','d1e135','d1e135-2')"><span id="d1e135" style="font-weight:bold; margin:5px; color:#BD9C8C;">+</span>example:Obervable-35f04c28-5fd2-4d72-8aae-2ad04ee1811f
+                        </div>
+                     </TD>
+                     <TD>
+                        <div style="cursor: pointer;" onclick="toggleDiv('700000000128','d1e135','d1e135-2')"><span id="d1e135-2" style="font-weight:bold; margin:5px; color:#BD9C8C;">+</span>
+                           Event
+                           
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR class="">
+                     <TD colspan="2">
+                        <div id="700000000128" class="collapsibleContent" style="overflow:hidden; display:none; padding:0px 7px;">
+                           <div id="example:Obervable-35f04c28-5fd2-4d72-8aae-2ad04ee1811f">
+                              <div class="debug idStack">id stack: example:Obervable-35f04c28-5fd2-4d72-8aae-2ad04ee1811f</div><br><div id="section">
+                                 <table class="one-column-emphasis">
+                                    <colgroup>
+                                       <col class="oce-first-obs">
+                                    </colgroup>
+                                    <tbody>
+                                       <tr>
+                                          <td>
+                                             <div class="container eventContainer event">
+                                                <div class="heading eventHeading event">
+                                                   <div class="debug idStack">id stack: example:Obervable-35f04c28-5fd2-4d72-8aae-2ad04ee1811f</div>
+                                                </div>
+                                                <div class="contents eventContents event">
+                                                   <div class="eventDescription description">
+                                                      description: Open Iran-Oil corrupted .doc file.
+                                                   </div>
+                                                   <div class="container">
+                                                      <div class="heading actions">Actions</div>
+                                                      <div class="contents actions">
+                                                         <div class="container action">
+                                                            <div class="heading action">ACTION Open (xsi type: cyboxVocabs:ActionTypeVocab-1.0)</div>
+                                                            <div class="contents action">
+                                                               <div class="debug idStack">id stack: example:Obervable-35f04c28-5fd2-4d72-8aae-2ad04ee1811f</div>
+                                                               <div class="container associatedObjects">
+                                                                  <div class="heading associatedObjects">Associated Objects
+                                                                     
+                                                                  </div>
+                                                                  <div class="contents associatedObjects">
+                                                                     <div class="container associatedObjectContainer associatedObject" id="example:Object-49d31c13-8d7b-4528-b8d6-ce8ed0d43ad7">
+                                                                        <div class="heading associatedObjectHeading associatedObject">Affected ○  FileObjectType ○ <span class="inlineObject">example:Object-49d31c13-8d7b-4528-b8d6-ce8ed0d43ad7</span> <span class="debug inlineOrByReferenceLabel">(inline object)</span><div class="debug idStack">id stack: example:Obervable-35f04c28-5fd2-4d72-8aae-2ad04ee1811f,example:Object-49d31c13-8d7b-4528-b8d6-ce8ed0d43ad7</div>
+                                                                        </div>
+                                                                        <div class="contents associatedObjectContents associatedObject">
+                                                                           <div class="associatedObjectDescription description">
+                                                                              description: 
+                                                                              The word document contains flash, which downloads a
+                                                                              corrupted mp4 file. The mp4 file itself is not anything special
+                                                                              but an 0C filled (22kb) mp4 file with a valid mp4
+                                                                              header.
+                                                                              
+                                                                           </div>
+                                                                           <div>
+                                                                              <fieldset>
+                                                                                 <legend>
+                                                                                    cybox properties
+                                                                                    (type: FileObjectType)
+                                                                                    
+                                                                                 </legend>
+                                                                                 <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                    <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">File_Name</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">Iran's Oil and Nuclear Situation.doc</span><div class="cyboxPropertiesLink"></div>
+                                                                                    </div>
+                                                                                    <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                 </div>
+                                                                                 <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                    <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Size_In_Bytes</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">106604</span><div class="cyboxPropertiesLink"></div>
+                                                                                    </div>
+                                                                                    <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                 </div>
+                                                                                 <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                    <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Hashes</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                          
+                                                                                          </span><div class="cyboxPropertiesLink"></div>
+                                                                                    </div>
+                                                                                    <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                       <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                          <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Hash</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                                
+                                                                                                
+                                                                                                </span><div class="cyboxPropertiesLink"></div>
+                                                                                          </div>
+                                                                                          <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Type</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">MD5</span><div class="cyboxPropertiesLink"></div>
+                                                                                                </div>
+                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                             </div>
+                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Simple_Hash_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">E92A4FC283EB2802AD6D0E24C7FCC857</span><div class="cyboxPropertiesLink"></div>
+                                                                                                </div>
+                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                             </div>
+                                                                                          </div>
+                                                                                       </div>
+                                                                                    </div>
+                                                                                 </div>
+                                                                              </fieldset>
+                                                                           </div>
+                                                                        </div>
+                                                                     </div>
+                                                                  </div>
+                                                               </div>
+                                                            </div>
+                                                         </div>
+                                                      </div>
+                                                   </div>
+                                                   <div></div>
+                                                </div>
+                                             </div>
+                                          </td>
+                                       </tr>
+                                    </tbody>
+                                 </table>
+                              </div>
+                           </div>
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR style="width:100%;font-style:italic;">
+                     <TD colspan="2">
+                        <div style="font-size:13px; font-style: italic; display:none;" id="3_ind_description">Test Email Description!! Test Email Description!! Test Email Description!! Test Email
+                           Description!! Test Email Description!! Test Email Description!! Test Email Description!!
+                           Test Email Description!! Test Email Description!! Test Email Description!! Test Email
+                           Description!! Test Email Description!! Test Email Description!! Test Email Description!!
+                           Test Email Description!! Test Email Description!! Test Email Description!! Test Email
+                           Description!! Test Email Description!! Test Email Description!! Test Email Description!!
+                           Test Email Description!! Test Email Description!! Test Email Description!! Test Email
+                           Description!! 
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR class="">
+                     <TD>
+                        <div id="fileObjAtt" class="collapsibleLabel" style="cursor: pointer;" onclick="toggleDiv('700000000184','d1e192','d1e192-2')"><span id="d1e192" style="font-weight:bold; margin:5px; color:#BD9C8C;">+</span>example:Observable-f005fbc6-7427-43ea-8e1e-9a341836f76b
+                        </div>
+                     </TD>
+                     <TD>
+                        <div style="cursor: pointer;" onclick="toggleDiv('700000000184','d1e192','d1e192-2')"><span id="d1e192-2" style="font-weight:bold; margin:5px; color:#BD9C8C;">+</span>
+                           Event
+                           
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR class="">
+                     <TD colspan="2">
+                        <div id="700000000184" class="collapsibleContent" style="overflow:hidden; display:none; padding:0px 7px;">
+                           <div id="example:Observable-f005fbc6-7427-43ea-8e1e-9a341836f76b">
+                              <div class="debug idStack">id stack: example:Observable-f005fbc6-7427-43ea-8e1e-9a341836f76b</div><br><div id="section">
+                                 <table class="one-column-emphasis">
+                                    <colgroup>
+                                       <col class="oce-first-obs">
+                                    </colgroup>
+                                    <tbody>
+                                       <tr>
+                                          <td>
+                                             <div class="container eventContainer event">
+                                                <div class="heading eventHeading event">
+                                                   <div class="debug idStack">id stack: example:Observable-f005fbc6-7427-43ea-8e1e-9a341836f76b</div>
+                                                </div>
+                                                <div class="contents eventContents event">
+                                                   <div class="eventDescription description">
+                                                      description: Download Iran-Oil invalid .mp4 downloader file.
+                                                   </div>
+                                                   <div class="container">
+                                                      <div class="heading actions">Actions</div>
+                                                      <div class="contents actions">
+                                                         <div class="container action">
+                                                            <div class="heading action">ACTION Download (xsi type: cyboxVocabs:ActionTypeVocab-1.0)</div>
+                                                            <div class="contents action">
+                                                               <div class="debug idStack">id stack: example:Observable-f005fbc6-7427-43ea-8e1e-9a341836f76b</div>
+                                                               <div class="container associatedObjects">
+                                                                  <div class="heading associatedObjects">Associated Objects
+                                                                     
+                                                                  </div>
+                                                                  <div class="contents associatedObjects">
+                                                                     <div class="container associatedObjectContainer associatedObject">
+                                                                        <div class="heading associatedObjectHeading associatedObject">
+                                                                           <div class="debug idStack">id stack: example:Observable-f005fbc6-7427-43ea-8e1e-9a341836f76b</div>
+                                                                           <div class="expandableContainer expandableSeparate collapsed">
+                                                                              <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Initiating ○  FileObjectType ○ example:Object-49d31c13-8d7b-4528-b8d6-ce8ed0d43ad7 <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                              <div class="expandableContents">
+                                                                                 <div class="container associatedObjectContainer associatedObject">
+                                                                                    <div class="heading associatedObjectHeading associatedObject">
+                                                                                       <div class="debug idStack">id stack: example:Observable-f005fbc6-7427-43ea-8e1e-9a341836f76b,example:Object-49d31c13-8d7b-4528-b8d6-ce8ed0d43ad7</div>
+                                                                                    </div>
+                                                                                    <div class="contents associatedObjectContents associatedObject">
+                                                                                       <div class="associatedObjectDescription description">
+                                                                                          description: 
+                                                                                          The word document contains flash, which downloads a
+                                                                                          corrupted mp4 file. The mp4 file itself is not anything special
+                                                                                          but an 0C filled (22kb) mp4 file with a valid mp4
+                                                                                          header.
+                                                                                          
+                                                                                       </div>
+                                                                                       <div>
+                                                                                          <fieldset>
+                                                                                             <legend>
+                                                                                                cybox properties
+                                                                                                (type: FileObjectType)
+                                                                                                
+                                                                                             </legend>
+                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">File_Name</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">Iran's Oil and Nuclear Situation.doc</span><div class="cyboxPropertiesLink"></div>
+                                                                                                </div>
+                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                             </div>
+                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Size_In_Bytes</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">106604</span><div class="cyboxPropertiesLink"></div>
+                                                                                                </div>
+                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                             </div>
+                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Hashes</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                                      
+                                                                                                      </span><div class="cyboxPropertiesLink"></div>
+                                                                                                </div>
+                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                                   <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                      <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Hash</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                                            
+                                                                                                            
+                                                                                                            </span><div class="cyboxPropertiesLink"></div>
+                                                                                                      </div>
+                                                                                                      <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                                         <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                            <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Type</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">MD5</span><div class="cyboxPropertiesLink"></div>
+                                                                                                            </div>
+                                                                                                            <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                         </div>
+                                                                                                         <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                            <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Simple_Hash_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">E92A4FC283EB2802AD6D0E24C7FCC857</span><div class="cyboxPropertiesLink"></div>
+                                                                                                            </div>
+                                                                                                            <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                         </div>
+                                                                                                      </div>
+                                                                                                   </div>
+                                                                                                </div>
+                                                                                             </div>
+                                                                                          </fieldset>
+                                                                                       </div>
+                                                                                    </div>
+                                                                                 </div>
+                                                                              </div>
+                                                                           </div>
+                                                                        </div>
+                                                                        <div class="contents associatedObjectContents associatedObject">
+                                                                           <div></div>
+                                                                        </div>
+                                                                     </div>
+                                                                     <div class="container associatedObjectContainer associatedObject" id="example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa">
+                                                                        <div class="heading associatedObjectHeading associatedObject">Affected ○  FileObjectType ○ <span class="inlineObject">example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa</span> <span class="debug inlineOrByReferenceLabel">(inline object)</span><div class="debug idStack">id stack: example:Observable-f005fbc6-7427-43ea-8e1e-9a341836f76b,example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa</div>
+                                                                        </div>
+                                                                        <div class="contents associatedObjectContents associatedObject">
+                                                                           <div class="associatedObjectDescription description">
+                                                                              description: 
+                                                                              This mp4 file causes memory corruption and code
+                                                                              execution via heap-spraying code injection.
+                                                                              
+                                                                           </div>
+                                                                           <div>
+                                                                              <fieldset>
+                                                                                 <legend>
+                                                                                    cybox properties
+                                                                                    (type: FileObjectType)
+                                                                                    
+                                                                                 </legend>
+                                                                                 <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                    <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">File_Name</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">test.mp4</span><div class="cyboxPropertiesLink"></div>
+                                                                                    </div>
+                                                                                    <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                 </div>
+                                                                                 <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                    <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Size_In_Bytes</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">22384</span><div class="cyboxPropertiesLink"></div>
+                                                                                    </div>
+                                                                                    <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                 </div>
+                                                                                 <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                    <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Hashes</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                          
+                                                                                          </span><div class="cyboxPropertiesLink"></div>
+                                                                                    </div>
+                                                                                    <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                       <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                          <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Hash</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                                
+                                                                                                
+                                                                                                </span><div class="cyboxPropertiesLink"></div>
+                                                                                          </div>
+                                                                                          <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Type</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">MD5</span><div class="cyboxPropertiesLink"></div>
+                                                                                                </div>
+                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                             </div>
+                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Simple_Hash_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">8933598C8B1FA5E493497B11C48DA4F2</span><div class="cyboxPropertiesLink"></div>
+                                                                                                </div>
+                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                             </div>
+                                                                                          </div>
+                                                                                       </div>
+                                                                                    </div>
+                                                                                 </div>
+                                                                              </fieldset>
+                                                                           </div>
+                                                                           <div class="container relatedObjects">
+                                                                              <div class="heading relatedObjects">Related Objects
+                                                                                 
+                                                                              </div>
+                                                                              <div class="contents relatedObjects">
+                                                                                 <div class="container relatedObjectContainer relatedObject">
+                                                                                    <div class="heading relatedObjectHeading relatedObject">
+                                                                                       <div class="debug idStack">id stack: example:Observable-f005fbc6-7427-43ea-8e1e-9a341836f76b,example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa</div>
+                                                                                       <div class="expandableContainer expandableSeparate collapsed">
+                                                                                          <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Downloaded_By ○  FileObjectType ○ example:Object-49d31c13-8d7b-4528-b8d6-ce8ed0d43ad7 <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                          <div class="expandableContents">
+                                                                                             <div class="container associatedObjectContainer associatedObject">
+                                                                                                <div class="heading associatedObjectHeading associatedObject">
+                                                                                                   <div class="debug idStack">id stack: example:Observable-f005fbc6-7427-43ea-8e1e-9a341836f76b,example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa,example:Object-49d31c13-8d7b-4528-b8d6-ce8ed0d43ad7</div>
+                                                                                                </div>
+                                                                                                <div class="contents associatedObjectContents associatedObject">
+                                                                                                   <div class="associatedObjectDescription description">
+                                                                                                      description: 
+                                                                                                      The word document contains flash, which downloads a
+                                                                                                      corrupted mp4 file. The mp4 file itself is not anything special
+                                                                                                      but an 0C filled (22kb) mp4 file with a valid mp4
+                                                                                                      header.
+                                                                                                      
+                                                                                                   </div>
+                                                                                                   <div>
+                                                                                                      <fieldset>
+                                                                                                         <legend>
+                                                                                                            cybox properties
+                                                                                                            (type: FileObjectType)
+                                                                                                            
+                                                                                                         </legend>
+                                                                                                         <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                            <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">File_Name</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">Iran's Oil and Nuclear Situation.doc</span><div class="cyboxPropertiesLink"></div>
+                                                                                                            </div>
+                                                                                                            <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                         </div>
+                                                                                                         <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                            <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Size_In_Bytes</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">106604</span><div class="cyboxPropertiesLink"></div>
+                                                                                                            </div>
+                                                                                                            <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                         </div>
+                                                                                                         <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                            <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Hashes</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                                                  
+                                                                                                                  </span><div class="cyboxPropertiesLink"></div>
+                                                                                                            </div>
+                                                                                                            <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                                               <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                  <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Hash</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        </span><div class="cyboxPropertiesLink"></div>
+                                                                                                                  </div>
+                                                                                                                  <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                                                     <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                        <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Type</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">MD5</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                     </div>
+                                                                                                                     <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                        <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Simple_Hash_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">E92A4FC283EB2802AD6D0E24C7FCC857</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                     </div>
+                                                                                                                  </div>
+                                                                                                               </div>
+                                                                                                            </div>
+                                                                                                         </div>
+                                                                                                      </fieldset>
+                                                                                                   </div>
+                                                                                                </div>
+                                                                                             </div>
+                                                                                          </div>
+                                                                                       </div>
+                                                                                    </div>
+                                                                                    <div class="contents relatedObjectContents relatedObject">
+                                                                                       <div></div>
+                                                                                    </div>
+                                                                                 </div>
+                                                                                 <div class="container relatedObjectContainer relatedObject">
+                                                                                    <div class="heading relatedObjectHeading relatedObject">
+                                                                                       <div class="debug idStack">id stack: example:Observable-f005fbc6-7427-43ea-8e1e-9a341836f76b,example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa</div>
+                                                                                       <div class="expandableContainer expandableSeparate collapsed">
+                                                                                          <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Downloaded_From ○  URIObjectType ○ example:Object-61041b8b-0c15-48a0-ac5f-b49488788010 <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                          <div class="expandableContents">
+                                                                                             <div class="container associatedObjectContainer associatedObject">
+                                                                                                <div class="heading associatedObjectHeading associatedObject">
+                                                                                                   <div class="debug idStack">id stack: example:Observable-f005fbc6-7427-43ea-8e1e-9a341836f76b,example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa,example:Object-61041b8b-0c15-48a0-ac5f-b49488788010</div>
+                                                                                                </div>
+                                                                                                <div class="contents associatedObjectContents associatedObject">
+                                                                                                   <div>
+                                                                                                      <fieldset>
+                                                                                                         <legend>
+                                                                                                            cybox properties
+                                                                                                            (type: URIObjectType)
+                                                                                                            <span class="cyboxPropertiesSingleConstraint"> [type=URL]</span></legend>
+                                                                                                         <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                            <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">http://208.115.230.76/test.mp4</span><div class="cyboxPropertiesLink"></div>
+                                                                                                            </div>
+                                                                                                            <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                         </div>
+                                                                                                      </fieldset>
+                                                                                                   </div>
+                                                                                                </div>
+                                                                                             </div>
+                                                                                          </div>
+                                                                                       </div>
+                                                                                    </div>
+                                                                                    <div class="contents relatedObjectContents relatedObject">
+                                                                                       <div></div>
+                                                                                    </div>
+                                                                                 </div>
+                                                                              </div>
+                                                                           </div>
+                                                                        </div>
+                                                                     </div>
+                                                                     <div class="container associatedObjectContainer associatedObject" id="example:Object-61041b8b-0c15-48a0-ac5f-b49488788010">
+                                                                        <div class="heading associatedObjectHeading associatedObject">Utilized ○  URIObjectType ○ <span class="inlineObject">example:Object-61041b8b-0c15-48a0-ac5f-b49488788010</span> <span class="debug inlineOrByReferenceLabel">(inline object)</span><div class="debug idStack">id stack: example:Observable-f005fbc6-7427-43ea-8e1e-9a341836f76b,example:Object-61041b8b-0c15-48a0-ac5f-b49488788010</div>
+                                                                        </div>
+                                                                        <div class="contents associatedObjectContents associatedObject">
+                                                                           <div>
+                                                                              <fieldset>
+                                                                                 <legend>
+                                                                                    cybox properties
+                                                                                    (type: URIObjectType)
+                                                                                    <span class="cyboxPropertiesSingleConstraint"> [type=URL]</span></legend>
+                                                                                 <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                    <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">http://208.115.230.76/test.mp4</span><div class="cyboxPropertiesLink"></div>
+                                                                                    </div>
+                                                                                    <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                 </div>
+                                                                              </fieldset>
+                                                                           </div>
+                                                                        </div>
+                                                                     </div>
+                                                                  </div>
+                                                               </div>
+                                                            </div>
+                                                         </div>
+                                                      </div>
+                                                   </div>
+                                                   <div></div>
+                                                </div>
+                                             </div>
+                                          </td>
+                                       </tr>
+                                    </tbody>
+                                 </table>
+                              </div>
+                           </div>
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR style="width:100%;font-style:italic;">
+                     <TD colspan="2">
+                        <div style="font-size:13px; font-style: italic; display:none;" id="4_ind_description">Test Email Description!! Test Email Description!! Test Email Description!! Test Email
+                           Description!! Test Email Description!! Test Email Description!! Test Email Description!!
+                           Test Email Description!! Test Email Description!! Test Email Description!! Test Email
+                           Description!! Test Email Description!! Test Email Description!! Test Email Description!!
+                           Test Email Description!! Test Email Description!! Test Email Description!! Test Email
+                           Description!! Test Email Description!! Test Email Description!! Test Email Description!!
+                           Test Email Description!! Test Email Description!! Test Email Description!! Test Email
+                           Description!! 
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR class="">
+                     <TD>
+                        <div id="fileObjAtt" class="collapsibleLabel" style="cursor: pointer;" onclick="toggleDiv('700000000277','d1e285','d1e285-2')"><span id="d1e285" style="font-weight:bold; margin:5px; color:#BD9C8C;">+</span>example:Observable-210f18f3-3874-4f9a-861d-71b328be90c6
+                        </div>
+                     </TD>
+                     <TD>
+                        <div style="cursor: pointer;" onclick="toggleDiv('700000000277','d1e285','d1e285-2')"><span id="d1e285-2" style="font-weight:bold; margin:5px; color:#BD9C8C;">+</span>
+                           Event
+                           
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR class="">
+                     <TD colspan="2">
+                        <div id="700000000277" class="collapsibleContent" style="overflow:hidden; display:none; padding:0px 7px;">
+                           <div id="example:Observable-210f18f3-3874-4f9a-861d-71b328be90c6">
+                              <div class="debug idStack">id stack: example:Observable-210f18f3-3874-4f9a-861d-71b328be90c6</div><br><div id="section">
+                                 <table class="one-column-emphasis">
+                                    <colgroup>
+                                       <col class="oce-first-obs">
+                                    </colgroup>
+                                    <tbody>
+                                       <tr>
+                                          <td>
+                                             <div class="container eventContainer event">
+                                                <div class="heading eventHeading event">
+                                                   <div class="debug idStack">id stack: example:Observable-210f18f3-3874-4f9a-861d-71b328be90c6</div>
+                                                </div>
+                                                <div class="contents eventContents event">
+                                                   <div class="eventDescription description">
+                                                      description: Create Iran-Oil .exe Trojan file.
+                                                   </div>
+                                                   <div class="container">
+                                                      <div class="heading actions">Actions</div>
+                                                      <div class="contents actions">
+                                                         <div class="container action">
+                                                            <div class="heading action">ACTION Create (xsi type: cyboxVocabs:ActionTypeVocab-1.0)</div>
+                                                            <div class="contents action">
+                                                               <div class="debug idStack">id stack: example:Observable-210f18f3-3874-4f9a-861d-71b328be90c6</div>
+                                                               <div class="container associatedObjects">
+                                                                  <div class="heading associatedObjects">Associated Objects
+                                                                     
+                                                                  </div>
+                                                                  <div class="contents associatedObjects">
+                                                                     <div class="container associatedObjectContainer associatedObject">
+                                                                        <div class="heading associatedObjectHeading associatedObject">
+                                                                           <div class="debug idStack">id stack: example:Observable-210f18f3-3874-4f9a-861d-71b328be90c6</div>
+                                                                           <div class="expandableContainer expandableSeparate collapsed">
+                                                                              <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Initiating ○  FileObjectType ○ example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                              <div class="expandableContents">
+                                                                                 <div class="container associatedObjectContainer associatedObject">
+                                                                                    <div class="heading associatedObjectHeading associatedObject">
+                                                                                       <div class="debug idStack">id stack: example:Observable-210f18f3-3874-4f9a-861d-71b328be90c6,example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa</div>
+                                                                                    </div>
+                                                                                    <div class="contents associatedObjectContents associatedObject">
+                                                                                       <div class="associatedObjectDescription description">
+                                                                                          description: 
+                                                                                          This mp4 file causes memory corruption and code
+                                                                                          execution via heap-spraying code injection.
+                                                                                          
+                                                                                       </div>
+                                                                                       <div>
+                                                                                          <fieldset>
+                                                                                             <legend>
+                                                                                                cybox properties
+                                                                                                (type: FileObjectType)
+                                                                                                
+                                                                                             </legend>
+                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">File_Name</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">test.mp4</span><div class="cyboxPropertiesLink"></div>
+                                                                                                </div>
+                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                             </div>
+                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Size_In_Bytes</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">22384</span><div class="cyboxPropertiesLink"></div>
+                                                                                                </div>
+                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                             </div>
+                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Hashes</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                                      
+                                                                                                      </span><div class="cyboxPropertiesLink"></div>
+                                                                                                </div>
+                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                                   <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                      <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Hash</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                                            
+                                                                                                            
+                                                                                                            </span><div class="cyboxPropertiesLink"></div>
+                                                                                                      </div>
+                                                                                                      <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                                         <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                            <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Type</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">MD5</span><div class="cyboxPropertiesLink"></div>
+                                                                                                            </div>
+                                                                                                            <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                         </div>
+                                                                                                         <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                            <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Simple_Hash_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">8933598C8B1FA5E493497B11C48DA4F2</span><div class="cyboxPropertiesLink"></div>
+                                                                                                            </div>
+                                                                                                            <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                         </div>
+                                                                                                      </div>
+                                                                                                   </div>
+                                                                                                </div>
+                                                                                             </div>
+                                                                                          </fieldset>
+                                                                                       </div>
+                                                                                       <div class="container relatedObjects">
+                                                                                          <div class="heading relatedObjects">Related Objects
+                                                                                             
+                                                                                          </div>
+                                                                                          <div class="contents relatedObjects">
+                                                                                             <div class="container relatedObjectContainer relatedObject">
+                                                                                                <div class="heading relatedObjectHeading relatedObject">
+                                                                                                   <div class="debug idStack">id stack: example:Observable-210f18f3-3874-4f9a-861d-71b328be90c6,example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa</div>
+                                                                                                   <div class="expandableContainer expandableSeparate collapsed">
+                                                                                                      <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Downloaded_By ○  FileObjectType ○ example:Object-49d31c13-8d7b-4528-b8d6-ce8ed0d43ad7 <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                                      <div class="expandableContents">
+                                                                                                         <div class="container associatedObjectContainer associatedObject">
+                                                                                                            <div class="heading associatedObjectHeading associatedObject">
+                                                                                                               <div class="debug idStack">id stack: example:Observable-210f18f3-3874-4f9a-861d-71b328be90c6,example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa,example:Object-49d31c13-8d7b-4528-b8d6-ce8ed0d43ad7</div>
+                                                                                                            </div>
+                                                                                                            <div class="contents associatedObjectContents associatedObject">
+                                                                                                               <div class="associatedObjectDescription description">
+                                                                                                                  description: 
+                                                                                                                  The word document contains flash, which downloads a
+                                                                                                                  corrupted mp4 file. The mp4 file itself is not anything special
+                                                                                                                  but an 0C filled (22kb) mp4 file with a valid mp4
+                                                                                                                  header.
+                                                                                                                  
+                                                                                                               </div>
+                                                                                                               <div>
+                                                                                                                  <fieldset>
+                                                                                                                     <legend>
+                                                                                                                        cybox properties
+                                                                                                                        (type: FileObjectType)
+                                                                                                                        
+                                                                                                                     </legend>
+                                                                                                                     <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                        <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">File_Name</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">Iran's Oil and Nuclear Situation.doc</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                     </div>
+                                                                                                                     <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                        <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Size_In_Bytes</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">106604</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                     </div>
+                                                                                                                     <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                        <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Hashes</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                                                              
+                                                                                                                              </span><div class="cyboxPropertiesLink"></div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                                                           <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                              <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Hash</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                                                                    
+                                                                                                                                    
+                                                                                                                                    </span><div class="cyboxPropertiesLink"></div>
+                                                                                                                              </div>
+                                                                                                                              <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                                                                 <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                    <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Type</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">MD5</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                    </div>
+                                                                                                                                    <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                                 </div>
+                                                                                                                                 <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                    <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Simple_Hash_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">E92A4FC283EB2802AD6D0E24C7FCC857</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                    </div>
+                                                                                                                                    <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                                 </div>
+                                                                                                                              </div>
+                                                                                                                           </div>
+                                                                                                                        </div>
+                                                                                                                     </div>
+                                                                                                                  </fieldset>
+                                                                                                               </div>
+                                                                                                            </div>
+                                                                                                         </div>
+                                                                                                      </div>
+                                                                                                   </div>
+                                                                                                </div>
+                                                                                                <div class="contents relatedObjectContents relatedObject">
+                                                                                                   <div></div>
+                                                                                                </div>
+                                                                                             </div>
+                                                                                             <div class="container relatedObjectContainer relatedObject">
+                                                                                                <div class="heading relatedObjectHeading relatedObject">
+                                                                                                   <div class="debug idStack">id stack: example:Observable-210f18f3-3874-4f9a-861d-71b328be90c6,example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa</div>
+                                                                                                   <div class="expandableContainer expandableSeparate collapsed">
+                                                                                                      <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Downloaded_From ○  URIObjectType ○ example:Object-61041b8b-0c15-48a0-ac5f-b49488788010 <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                                      <div class="expandableContents">
+                                                                                                         <div class="container associatedObjectContainer associatedObject">
+                                                                                                            <div class="heading associatedObjectHeading associatedObject">
+                                                                                                               <div class="debug idStack">id stack: example:Observable-210f18f3-3874-4f9a-861d-71b328be90c6,example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa,example:Object-61041b8b-0c15-48a0-ac5f-b49488788010</div>
+                                                                                                            </div>
+                                                                                                            <div class="contents associatedObjectContents associatedObject">
+                                                                                                               <div>
+                                                                                                                  <fieldset>
+                                                                                                                     <legend>
+                                                                                                                        cybox properties
+                                                                                                                        (type: URIObjectType)
+                                                                                                                        <span class="cyboxPropertiesSingleConstraint"> [type=URL]</span></legend>
+                                                                                                                     <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                        <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">http://208.115.230.76/test.mp4</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                     </div>
+                                                                                                                  </fieldset>
+                                                                                                               </div>
+                                                                                                            </div>
+                                                                                                         </div>
+                                                                                                      </div>
+                                                                                                   </div>
+                                                                                                </div>
+                                                                                                <div class="contents relatedObjectContents relatedObject">
+                                                                                                   <div></div>
+                                                                                                </div>
+                                                                                             </div>
+                                                                                          </div>
+                                                                                       </div>
+                                                                                    </div>
+                                                                                 </div>
+                                                                              </div>
+                                                                           </div>
+                                                                        </div>
+                                                                        <div class="contents associatedObjectContents associatedObject">
+                                                                           <div></div>
+                                                                        </div>
+                                                                     </div>
+                                                                     <div class="container associatedObjectContainer associatedObject" id="example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c">
+                                                                        <div class="heading associatedObjectHeading associatedObject">Affected ○  FileObjectType ○ <span class="inlineObject">example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c</span> <span class="debug inlineOrByReferenceLabel">(inline object)</span><div class="debug idStack">id stack: example:Observable-210f18f3-3874-4f9a-861d-71b328be90c6,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c</div>
+                                                                        </div>
+                                                                        <div class="contents associatedObjectContents associatedObject">
+                                                                           <div class="associatedObjectDescription description">
+                                                                              description: 
+                                                                              The file (us.exe MD5: FD1BE09E499E8E380424B3835FC973A8
+                                                                              4861440 bytes) is created in the logged in user %Temp%
+                                                                              directory. The size of the embedded file is 22.5 KB (23040
+                                                                              bytes) and the size of the created us.exe is 4.63MB. It is an
+                                                                              odd discrepancy until you look at the file and it looks like the
+                                                                              code is repeated over and over - 211 times. The file resource
+                                                                              section indicates the file is meant to look like a java updater,
+                                                                              which is always larger than 22.5KB and that would explain all
+                                                                              this padding, which is done at the time when the file is being
+                                                                              written to the disk.
+                                                                              
+                                                                           </div>
+                                                                           <div>
+                                                                              <fieldset>
+                                                                                 <legend>
+                                                                                    cybox properties
+                                                                                    (type: FileObjectType)
+                                                                                    
+                                                                                 </legend>
+                                                                                 <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                    <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">File_Name</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">us.exe</span><div class="cyboxPropertiesLink"></div>
+                                                                                    </div>
+                                                                                    <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                 </div>
+                                                                                 <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                    <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">File_Path</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">%Temp%</span><div class="cyboxPropertiesLink"></div>
+                                                                                    </div>
+                                                                                    <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                 </div>
+                                                                                 <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                    <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Size_In_Bytes</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">4861440</span><div class="cyboxPropertiesLink"></div>
+                                                                                    </div>
+                                                                                    <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                 </div>
+                                                                                 <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                    <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Hashes</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                          
+                                                                                          </span><div class="cyboxPropertiesLink"></div>
+                                                                                    </div>
+                                                                                    <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                       <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                          <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Hash</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                                
+                                                                                                
+                                                                                                </span><div class="cyboxPropertiesLink"></div>
+                                                                                          </div>
+                                                                                          <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Type</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">MD5</span><div class="cyboxPropertiesLink"></div>
+                                                                                                </div>
+                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                             </div>
+                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Simple_Hash_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">FD1BE09E499E8E380424B3835FC973A8</span><div class="cyboxPropertiesLink"></div>
+                                                                                                </div>
+                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                             </div>
+                                                                                          </div>
+                                                                                       </div>
+                                                                                    </div>
+                                                                                 </div>
+                                                                              </fieldset>
+                                                                           </div>
+                                                                           <div class="container relatedObjects">
+                                                                              <div class="heading relatedObjects">Related Objects
+                                                                                 
+                                                                              </div>
+                                                                              <div class="contents relatedObjects">
+                                                                                 <div class="container relatedObjectContainer relatedObject">
+                                                                                    <div class="heading relatedObjectHeading relatedObject">
+                                                                                       <div class="debug idStack">id stack: example:Observable-210f18f3-3874-4f9a-861d-71b328be90c6,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c</div>
+                                                                                       <div class="expandableContainer expandableSeparate collapsed">
+                                                                                          <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Created_By ○  FileObjectType ○ example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                          <div class="expandableContents">
+                                                                                             <div class="container associatedObjectContainer associatedObject">
+                                                                                                <div class="heading associatedObjectHeading associatedObject">
+                                                                                                   <div class="debug idStack">id stack: example:Observable-210f18f3-3874-4f9a-861d-71b328be90c6,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa</div>
+                                                                                                </div>
+                                                                                                <div class="contents associatedObjectContents associatedObject">
+                                                                                                   <div class="associatedObjectDescription description">
+                                                                                                      description: 
+                                                                                                      This mp4 file causes memory corruption and code
+                                                                                                      execution via heap-spraying code injection.
+                                                                                                      
+                                                                                                   </div>
+                                                                                                   <div>
+                                                                                                      <fieldset>
+                                                                                                         <legend>
+                                                                                                            cybox properties
+                                                                                                            (type: FileObjectType)
+                                                                                                            
+                                                                                                         </legend>
+                                                                                                         <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                            <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">File_Name</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">test.mp4</span><div class="cyboxPropertiesLink"></div>
+                                                                                                            </div>
+                                                                                                            <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                         </div>
+                                                                                                         <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                            <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Size_In_Bytes</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">22384</span><div class="cyboxPropertiesLink"></div>
+                                                                                                            </div>
+                                                                                                            <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                         </div>
+                                                                                                         <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                            <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Hashes</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                                                  
+                                                                                                                  </span><div class="cyboxPropertiesLink"></div>
+                                                                                                            </div>
+                                                                                                            <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                                               <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                  <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Hash</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        </span><div class="cyboxPropertiesLink"></div>
+                                                                                                                  </div>
+                                                                                                                  <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                                                     <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                        <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Type</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">MD5</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                     </div>
+                                                                                                                     <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                        <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Simple_Hash_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">8933598C8B1FA5E493497B11C48DA4F2</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                     </div>
+                                                                                                                  </div>
+                                                                                                               </div>
+                                                                                                            </div>
+                                                                                                         </div>
+                                                                                                      </fieldset>
+                                                                                                   </div>
+                                                                                                   <div class="container relatedObjects">
+                                                                                                      <div class="heading relatedObjects">Related Objects
+                                                                                                         
+                                                                                                      </div>
+                                                                                                      <div class="contents relatedObjects">
+                                                                                                         <div class="container relatedObjectContainer relatedObject">
+                                                                                                            <div class="heading relatedObjectHeading relatedObject">
+                                                                                                               <div class="debug idStack">id stack: example:Observable-210f18f3-3874-4f9a-861d-71b328be90c6,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa</div>
+                                                                                                               <div class="expandableContainer expandableSeparate collapsed">
+                                                                                                                  <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Downloaded_By ○  FileObjectType ○ example:Object-49d31c13-8d7b-4528-b8d6-ce8ed0d43ad7 <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                                                  <div class="expandableContents">
+                                                                                                                     <div class="container associatedObjectContainer associatedObject">
+                                                                                                                        <div class="heading associatedObjectHeading associatedObject">
+                                                                                                                           <div class="debug idStack">id stack: example:Observable-210f18f3-3874-4f9a-861d-71b328be90c6,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa,example:Object-49d31c13-8d7b-4528-b8d6-ce8ed0d43ad7</div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents associatedObjectContents associatedObject">
+                                                                                                                           <div class="associatedObjectDescription description">
+                                                                                                                              description: 
+                                                                                                                              The word document contains flash, which downloads a
+                                                                                                                              corrupted mp4 file. The mp4 file itself is not anything special
+                                                                                                                              but an 0C filled (22kb) mp4 file with a valid mp4
+                                                                                                                              header.
+                                                                                                                              
+                                                                                                                           </div>
+                                                                                                                           <div>
+                                                                                                                              <fieldset>
+                                                                                                                                 <legend>
+                                                                                                                                    cybox properties
+                                                                                                                                    (type: FileObjectType)
+                                                                                                                                    
+                                                                                                                                 </legend>
+                                                                                                                                 <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                    <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">File_Name</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">Iran's Oil and Nuclear Situation.doc</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                    </div>
+                                                                                                                                    <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                                 </div>
+                                                                                                                                 <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                    <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Size_In_Bytes</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">106604</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                    </div>
+                                                                                                                                    <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                                 </div>
+                                                                                                                                 <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                    <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Hashes</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                                                                          
+                                                                                                                                          </span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                    </div>
+                                                                                                                                    <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                                                                       <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                          <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Hash</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                                                                                
+                                                                                                                                                
+                                                                                                                                                </span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                          </div>
+                                                                                                                                          <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Type</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">MD5</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                                </div>
+                                                                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                                             </div>
+                                                                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Simple_Hash_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">E92A4FC283EB2802AD6D0E24C7FCC857</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                                </div>
+                                                                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                                             </div>
+                                                                                                                                          </div>
+                                                                                                                                       </div>
+                                                                                                                                    </div>
+                                                                                                                                 </div>
+                                                                                                                              </fieldset>
+                                                                                                                           </div>
+                                                                                                                        </div>
+                                                                                                                     </div>
+                                                                                                                  </div>
+                                                                                                               </div>
+                                                                                                            </div>
+                                                                                                            <div class="contents relatedObjectContents relatedObject">
+                                                                                                               <div></div>
+                                                                                                            </div>
+                                                                                                         </div>
+                                                                                                         <div class="container relatedObjectContainer relatedObject">
+                                                                                                            <div class="heading relatedObjectHeading relatedObject">
+                                                                                                               <div class="debug idStack">id stack: example:Observable-210f18f3-3874-4f9a-861d-71b328be90c6,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa</div>
+                                                                                                               <div class="expandableContainer expandableSeparate collapsed">
+                                                                                                                  <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Downloaded_From ○  URIObjectType ○ example:Object-61041b8b-0c15-48a0-ac5f-b49488788010 <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                                                  <div class="expandableContents">
+                                                                                                                     <div class="container associatedObjectContainer associatedObject">
+                                                                                                                        <div class="heading associatedObjectHeading associatedObject">
+                                                                                                                           <div class="debug idStack">id stack: example:Observable-210f18f3-3874-4f9a-861d-71b328be90c6,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa,example:Object-61041b8b-0c15-48a0-ac5f-b49488788010</div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents associatedObjectContents associatedObject">
+                                                                                                                           <div>
+                                                                                                                              <fieldset>
+                                                                                                                                 <legend>
+                                                                                                                                    cybox properties
+                                                                                                                                    (type: URIObjectType)
+                                                                                                                                    <span class="cyboxPropertiesSingleConstraint"> [type=URL]</span></legend>
+                                                                                                                                 <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                    <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">http://208.115.230.76/test.mp4</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                    </div>
+                                                                                                                                    <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                                 </div>
+                                                                                                                              </fieldset>
+                                                                                                                           </div>
+                                                                                                                        </div>
+                                                                                                                     </div>
+                                                                                                                  </div>
+                                                                                                               </div>
+                                                                                                            </div>
+                                                                                                            <div class="contents relatedObjectContents relatedObject">
+                                                                                                               <div></div>
+                                                                                                            </div>
+                                                                                                         </div>
+                                                                                                      </div>
+                                                                                                   </div>
+                                                                                                </div>
+                                                                                             </div>
+                                                                                          </div>
+                                                                                       </div>
+                                                                                    </div>
+                                                                                    <div class="contents relatedObjectContents relatedObject">
+                                                                                       <div></div>
+                                                                                    </div>
+                                                                                 </div>
+                                                                                 <div class="container relatedObjectContainer relatedObject">
+                                                                                    <div class="heading relatedObjectHeading relatedObject">
+                                                                                       <div class="debug idStack">id stack: example:Observable-210f18f3-3874-4f9a-861d-71b328be90c6,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c</div>
+                                                                                       <div class="expandableContainer expandableSeparate collapsed">
+                                                                                          <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Connected_To ○  URIObjectType ○ example:Object-41b220d8-4c45-48de-9d08-30d661b2dc8e <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                          <div class="expandableContents">
+                                                                                             <div class="container objectContainer object">
+                                                                                                <div class="heading objectHeading object">
+                                                                                                   <div class="debug idStack">id stack: example:Observable-210f18f3-3874-4f9a-861d-71b328be90c6,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-41b220d8-4c45-48de-9d08-30d661b2dc8e</div>
+                                                                                                </div>
+                                                                                                <div class="contents objectContents object">
+                                                                                                   <div>
+                                                                                                      <fieldset>
+                                                                                                         <legend>
+                                                                                                            cybox properties
+                                                                                                            (type: URIObjectType)
+                                                                                                            
+                                                                                                         </legend>
+                                                                                                         <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                            <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">www.documents.myPicture.info</span><div class="cyboxPropertiesLink"></div>
+                                                                                                            </div>
+                                                                                                            <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                         </div>
+                                                                                                      </fieldset>
+                                                                                                   </div>
+                                                                                                   <div class="container relatedObjects">
+                                                                                                      <div class="heading relatedObjects">Related Objects
+                                                                                                         
+                                                                                                      </div>
+                                                                                                      <div class="contents relatedObjects">
+                                                                                                         <div class="container relatedObjectContainer relatedObject">
+                                                                                                            <div class="heading relatedObjectHeading relatedObject">
+                                                                                                               <div class="debug idStack">id stack: example:Observable-210f18f3-3874-4f9a-861d-71b328be90c6,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-41b220d8-4c45-48de-9d08-30d661b2dc8e</div>
+                                                                                                               <div class="expandableContainer expandableSeparate collapsed">
+                                                                                                                  <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Resolved_To ○  AddressObjectType ○ example:Object-61aa225b-90ef-415c-8bbd-a17282e457c9 <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                                                  <div class="expandableContents">
+                                                                                                                     <div class="container objectContainer object">
+                                                                                                                        <div class="heading objectHeading object">
+                                                                                                                           <div class="debug idStack">id stack: example:Observable-210f18f3-3874-4f9a-861d-71b328be90c6,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-41b220d8-4c45-48de-9d08-30d661b2dc8e,example:Object-61aa225b-90ef-415c-8bbd-a17282e457c9</div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents objectContents object">
+                                                                                                                           <div>
+                                                                                                                              <fieldset>
+                                                                                                                                 <legend>
+                                                                                                                                    cybox properties
+                                                                                                                                    (type: AddressObjectType)
+                                                                                                                                    <span class="cyboxPropertiesSingleConstraint"> [category=ipv4-addr]</span></legend>
+                                                                                                                                 <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                    <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Address_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">199.192.156.134</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                    </div>
+                                                                                                                                    <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                                 </div>
+                                                                                                                              </fieldset>
+                                                                                                                           </div>
+                                                                                                                        </div>
+                                                                                                                     </div>
+                                                                                                                  </div>
+                                                                                                               </div>
+                                                                                                            </div>
+                                                                                                            <div class="contents relatedObjectContents relatedObject">
+                                                                                                               <div></div>
+                                                                                                            </div>
+                                                                                                         </div>
+                                                                                                      </div>
+                                                                                                   </div>
+                                                                                                </div>
+                                                                                             </div>
+                                                                                          </div>
+                                                                                       </div>
+                                                                                    </div>
+                                                                                    <div class="contents relatedObjectContents relatedObject">
+                                                                                       <div></div>
+                                                                                    </div>
+                                                                                 </div>
+                                                                                 <div class="container relatedObjectContainer relatedObject">
+                                                                                    <div class="heading relatedObjectHeading relatedObject">
+                                                                                       <div class="debug idStack">id stack: example:Observable-210f18f3-3874-4f9a-861d-71b328be90c6,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c</div>
+                                                                                       <div class="expandableContainer expandableSeparate collapsed">
+                                                                                          <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Connected_To ○  AddressObjectType ○ example:Object-61aa225b-90ef-415c-8bbd-a17282e457c9 <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                          <div class="expandableContents">
+                                                                                             <div class="container objectContainer object">
+                                                                                                <div class="heading objectHeading object">
+                                                                                                   <div class="debug idStack">id stack: example:Observable-210f18f3-3874-4f9a-861d-71b328be90c6,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-61aa225b-90ef-415c-8bbd-a17282e457c9</div>
+                                                                                                </div>
+                                                                                                <div class="contents objectContents object">
+                                                                                                   <div>
+                                                                                                      <fieldset>
+                                                                                                         <legend>
+                                                                                                            cybox properties
+                                                                                                            (type: AddressObjectType)
+                                                                                                            <span class="cyboxPropertiesSingleConstraint"> [category=ipv4-addr]</span></legend>
+                                                                                                         <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                            <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Address_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">199.192.156.134</span><div class="cyboxPropertiesLink"></div>
+                                                                                                            </div>
+                                                                                                            <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                         </div>
+                                                                                                      </fieldset>
+                                                                                                   </div>
+                                                                                                </div>
+                                                                                             </div>
+                                                                                          </div>
+                                                                                       </div>
+                                                                                    </div>
+                                                                                    <div class="contents relatedObjectContents relatedObject">
+                                                                                       <div></div>
+                                                                                    </div>
+                                                                                 </div>
+                                                                                 <div class="container relatedObjectContainer relatedObject">
+                                                                                    <div class="heading relatedObjectHeading relatedObject">
+                                                                                       <div class="debug idStack">id stack: example:Observable-210f18f3-3874-4f9a-861d-71b328be90c6,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c</div>
+                                                                                       <div class="expandableContainer expandableSeparate collapsed">
+                                                                                          <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Connected_To ○  URIObjectType ○ example:Object-568db11e-39ee-43d7-83d8-032bdec3801a <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                          <div class="expandableContents">
+                                                                                             <div class="container objectContainer object">
+                                                                                                <div class="heading objectHeading object">
+                                                                                                   <div class="debug idStack">id stack: example:Observable-210f18f3-3874-4f9a-861d-71b328be90c6,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-568db11e-39ee-43d7-83d8-032bdec3801a</div>
+                                                                                                </div>
+                                                                                                <div class="contents objectContents object">
+                                                                                                   <div>
+                                                                                                      <fieldset>
+                                                                                                         <legend>
+                                                                                                            cybox properties
+                                                                                                            (type: URIObjectType)
+                                                                                                            <span class="cyboxPropertiesSingleConstraint"> [type=URL]</span></legend>
+                                                                                                         <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                            <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">documents.myPicture.info</span><div class="cyboxPropertiesLink"></div>
+                                                                                                            </div>
+                                                                                                            <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                         </div>
+                                                                                                      </fieldset>
+                                                                                                   </div>
+                                                                                                   <div class="container relatedObjects">
+                                                                                                      <div class="heading relatedObjects">Related Objects
+                                                                                                         
+                                                                                                      </div>
+                                                                                                      <div class="contents relatedObjects">
+                                                                                                         <div class="container relatedObjectContainer relatedObject">
+                                                                                                            <div class="heading relatedObjectHeading relatedObject">
+                                                                                                               <div class="debug idStack">id stack: example:Observable-210f18f3-3874-4f9a-861d-71b328be90c6,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-568db11e-39ee-43d7-83d8-032bdec3801a</div>
+                                                                                                               <div class="expandableContainer expandableSeparate collapsed">
+                                                                                                                  <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Resolved_To ○  AddressObjectType ○ example:Object-80bea4d1-0e70-4a03-a54f-e40373bf94f1 <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                                                  <div class="expandableContents">
+                                                                                                                     <div class="container objectContainer object">
+                                                                                                                        <div class="heading objectHeading object">
+                                                                                                                           <div class="debug idStack">id stack: example:Observable-210f18f3-3874-4f9a-861d-71b328be90c6,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-568db11e-39ee-43d7-83d8-032bdec3801a,example:Object-80bea4d1-0e70-4a03-a54f-e40373bf94f1</div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents objectContents object">
+                                                                                                                           <div>
+                                                                                                                              <fieldset>
+                                                                                                                                 <legend>
+                                                                                                                                    cybox properties
+                                                                                                                                    (type: AddressObjectType)
+                                                                                                                                    <span class="cyboxPropertiesSingleConstraint"> [category=ipv4-addr]</span></legend>
+                                                                                                                                 <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                    <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Address_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">199.192.156.134</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                    </div>
+                                                                                                                                    <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                                 </div>
+                                                                                                                              </fieldset>
+                                                                                                                           </div>
+                                                                                                                        </div>
+                                                                                                                     </div>
+                                                                                                                  </div>
+                                                                                                               </div>
+                                                                                                            </div>
+                                                                                                            <div class="contents relatedObjectContents relatedObject">
+                                                                                                               <div></div>
+                                                                                                            </div>
+                                                                                                         </div>
+                                                                                                      </div>
+                                                                                                   </div>
+                                                                                                </div>
+                                                                                             </div>
+                                                                                          </div>
+                                                                                       </div>
+                                                                                    </div>
+                                                                                    <div class="contents relatedObjectContents relatedObject">
+                                                                                       <div></div>
+                                                                                    </div>
+                                                                                 </div>
+                                                                                 <div class="container relatedObjectContainer relatedObject">
+                                                                                    <div class="heading relatedObjectHeading relatedObject">
+                                                                                       <div class="debug idStack">id stack: example:Observable-210f18f3-3874-4f9a-861d-71b328be90c6,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c</div>
+                                                                                       <div class="expandableContainer expandableSeparate collapsed">
+                                                                                          <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Connected_To ○  AddressObjectType ○ example:Object-80bea4d1-0e70-4a03-a54f-e40373bf94f1 <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                          <div class="expandableContents">
+                                                                                             <div class="container objectContainer object">
+                                                                                                <div class="heading objectHeading object">
+                                                                                                   <div class="debug idStack">id stack: example:Observable-210f18f3-3874-4f9a-861d-71b328be90c6,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-80bea4d1-0e70-4a03-a54f-e40373bf94f1</div>
+                                                                                                </div>
+                                                                                                <div class="contents objectContents object">
+                                                                                                   <div>
+                                                                                                      <fieldset>
+                                                                                                         <legend>
+                                                                                                            cybox properties
+                                                                                                            (type: AddressObjectType)
+                                                                                                            <span class="cyboxPropertiesSingleConstraint"> [category=ipv4-addr]</span></legend>
+                                                                                                         <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                            <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Address_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">199.192.156.134</span><div class="cyboxPropertiesLink"></div>
+                                                                                                            </div>
+                                                                                                            <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                         </div>
+                                                                                                      </fieldset>
+                                                                                                   </div>
+                                                                                                </div>
+                                                                                             </div>
+                                                                                          </div>
+                                                                                       </div>
+                                                                                    </div>
+                                                                                    <div class="contents relatedObjectContents relatedObject">
+                                                                                       <div></div>
+                                                                                    </div>
+                                                                                 </div>
+                                                                                 <div class="container relatedObjectContainer relatedObject">
+                                                                                    <div class="heading relatedObjectHeading relatedObject">
+                                                                                       <div class="debug idStack">id stack: example:Observable-210f18f3-3874-4f9a-861d-71b328be90c6,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c</div>
+                                                                                       <div class="expandableContainer expandableSeparate collapsed">
+                                                                                          <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Connected_To ○  URIObjectType ○ example:Object-af7cb3b6-d70b-4b3b-b24f-7cfad739710f <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                          <div class="expandableContents">
+                                                                                             <div class="container objectContainer object">
+                                                                                                <div class="heading objectHeading object">
+                                                                                                   <div class="debug idStack">id stack: example:Observable-210f18f3-3874-4f9a-861d-71b328be90c6,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-af7cb3b6-d70b-4b3b-b24f-7cfad739710f</div>
+                                                                                                </div>
+                                                                                                <div class="contents objectContents object">
+                                                                                                   <div>
+                                                                                                      <fieldset>
+                                                                                                         <legend>
+                                                                                                            cybox properties
+                                                                                                            (type: URIObjectType)
+                                                                                                            <span class="cyboxPropertiesSingleConstraint"> [type=URL]</span></legend>
+                                                                                                         <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                            <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">ftp.documents.myPicture.info</span><div class="cyboxPropertiesLink"></div>
+                                                                                                            </div>
+                                                                                                            <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                         </div>
+                                                                                                      </fieldset>
+                                                                                                   </div>
+                                                                                                   <div class="container relatedObjects">
+                                                                                                      <div class="heading relatedObjects">Related Objects
+                                                                                                         
+                                                                                                      </div>
+                                                                                                      <div class="contents relatedObjects">
+                                                                                                         <div class="container relatedObjectContainer relatedObject">
+                                                                                                            <div class="heading relatedObjectHeading relatedObject">
+                                                                                                               <div class="debug idStack">id stack: example:Observable-210f18f3-3874-4f9a-861d-71b328be90c6,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-af7cb3b6-d70b-4b3b-b24f-7cfad739710f</div>
+                                                                                                               <div class="expandableContainer expandableSeparate collapsed">
+                                                                                                                  <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Resolved_To ○  AddressObjectType ○ example:Object-5ceb9d54-24e2-4627-948d-6b92ac81962a <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                                                  <div class="expandableContents">
+                                                                                                                     <div class="container objectContainer object">
+                                                                                                                        <div class="heading objectHeading object">
+                                                                                                                           <div class="debug idStack">id stack: example:Observable-210f18f3-3874-4f9a-861d-71b328be90c6,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-af7cb3b6-d70b-4b3b-b24f-7cfad739710f,example:Object-5ceb9d54-24e2-4627-948d-6b92ac81962a</div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents objectContents object">
+                                                                                                                           <div>
+                                                                                                                              <fieldset>
+                                                                                                                                 <legend>
+                                                                                                                                    cybox properties
+                                                                                                                                    (type: AddressObjectType)
+                                                                                                                                    <span class="cyboxPropertiesSingleConstraint"> [category=ipv4-addr]</span></legend>
+                                                                                                                                 <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                    <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Address_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">199.192.156.134</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                    </div>
+                                                                                                                                    <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                                 </div>
+                                                                                                                              </fieldset>
+                                                                                                                           </div>
+                                                                                                                        </div>
+                                                                                                                     </div>
+                                                                                                                  </div>
+                                                                                                               </div>
+                                                                                                            </div>
+                                                                                                            <div class="contents relatedObjectContents relatedObject">
+                                                                                                               <div></div>
+                                                                                                            </div>
+                                                                                                         </div>
+                                                                                                      </div>
+                                                                                                   </div>
+                                                                                                </div>
+                                                                                             </div>
+                                                                                          </div>
+                                                                                       </div>
+                                                                                    </div>
+                                                                                    <div class="contents relatedObjectContents relatedObject">
+                                                                                       <div></div>
+                                                                                    </div>
+                                                                                 </div>
+                                                                                 <div class="container relatedObjectContainer relatedObject">
+                                                                                    <div class="heading relatedObjectHeading relatedObject">
+                                                                                       <div class="debug idStack">id stack: example:Observable-210f18f3-3874-4f9a-861d-71b328be90c6,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c</div>
+                                                                                       <div class="objectReference nonexpandableContainer"> <span class="externalLinkWarning">[external]</span>  ○ example:guid-5ceb9d54-24e2-4627-948d-6b92ac81962a <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                    </div>
+                                                                                    <div class="contents relatedObjectContents relatedObject">
+                                                                                       <div></div>
+                                                                                    </div>
+                                                                                 </div>
+                                                                              </div>
+                                                                           </div>
+                                                                        </div>
+                                                                     </div>
+                                                                  </div>
+                                                               </div>
+                                                            </div>
+                                                         </div>
+                                                      </div>
+                                                   </div>
+                                                   <div></div>
+                                                </div>
+                                             </div>
+                                          </td>
+                                       </tr>
+                                    </tbody>
+                                 </table>
+                              </div>
+                           </div>
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR>
+                     <TD colspan="2">
+                        <hr>
+                     </TD>
+                  </TR>
+                  <TR style="width:100%;font-style:italic;">
+                     <TD><strong>TEST2:indicator-f205f08f-818b-4670-8491-45fad9e37ee4</strong><div style="font-size:13px; font-style: italic; display:none;" id="5_description">This collection of observables were observed as part of the widespread "Iran-Oil"
+                           (among many other names used) attack campaign in March 2012
+                        </div><a style="cursor:pointer; color:grey;" onclick="showLongIndicatorDescription(this, 5);">
+                           (Show Long Description)
+                           </a></TD>
+                     <TD>
+                        (Malware Artifacts)
+                        
+                     </TD>
+                  </TR>
+                  <TR style="width:100%;font-style:italic;">
+                     <TD colspan="2">
+                        <div style="font-size:13px; font-style: italic; display:none;" id="5_ind_description">Test Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!! Test
+                           Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre
+                           Artifact Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre Artifact
+                           Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!!
+                           Test Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!! Test
+                           Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre
+                           Artifact Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre Artifact
+                           Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!!
+                           Test Malwawre Artifact Information!!!! 
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR class="">
+                     <TD>
+                        <div id="fileObjAtt" class="collapsibleLabel" style="cursor: pointer;" onclick="toggleDiv('700000000398','d1e407','d1e407-2')"><span id="d1e407" style="font-weight:bold; margin:5px; color:#BD9C8C;">+</span>example:Observable-b650c988-aac7-45ff-967d-9f1e5fc66161
+                        </div>
+                     </TD>
+                     <TD>
+                        <div style="cursor: pointer;" onclick="toggleDiv('700000000398','d1e407','d1e407-2')"><span id="d1e407-2" style="font-weight:bold; margin:5px; color:#BD9C8C;">+</span>
+                           Event
+                           
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR class="">
+                     <TD colspan="2">
+                        <div id="700000000398" class="collapsibleContent" style="overflow:hidden; display:none; padding:0px 7px;">
+                           <div id="example:Observable-b650c988-aac7-45ff-967d-9f1e5fc66161">
+                              <div class="debug idStack">id stack: example:Observable-b650c988-aac7-45ff-967d-9f1e5fc66161</div><br><div id="section">
+                                 <table class="one-column-emphasis">
+                                    <colgroup>
+                                       <col class="oce-first-obs">
+                                    </colgroup>
+                                    <tbody>
+                                       <tr>
+                                          <td>
+                                             <div class="container eventContainer event">
+                                                <div class="heading eventHeading event">
+                                                   <div class="debug idStack">id stack: example:Observable-b650c988-aac7-45ff-967d-9f1e5fc66161</div>
+                                                </div>
+                                                <div class="contents eventContents event">
+                                                   <div class="eventDescription description">
+                                                      description: Execute Iran-Oil .exe Trojan file.
+                                                   </div>
+                                                   <div class="container">
+                                                      <div class="heading actions">Actions</div>
+                                                      <div class="contents actions">
+                                                         <div class="container action">
+                                                            <div class="heading action">ACTION Execute (xsi type: cyboxVocabs:ActionTypeVocab-1.0)</div>
+                                                            <div class="contents action">
+                                                               <div class="debug idStack">id stack: example:Observable-b650c988-aac7-45ff-967d-9f1e5fc66161</div>
+                                                               <div class="container associatedObjects">
+                                                                  <div class="heading associatedObjects">Associated Objects
+                                                                     
+                                                                  </div>
+                                                                  <div class="contents associatedObjects">
+                                                                     <div class="container associatedObjectContainer associatedObject">
+                                                                        <div class="heading associatedObjectHeading associatedObject">
+                                                                           <div class="debug idStack">id stack: example:Observable-b650c988-aac7-45ff-967d-9f1e5fc66161</div>
+                                                                           <div class="expandableContainer expandableSeparate collapsed">
+                                                                              <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Initiating ○  FileObjectType ○ example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                              <div class="expandableContents">
+                                                                                 <div class="container associatedObjectContainer associatedObject">
+                                                                                    <div class="heading associatedObjectHeading associatedObject">
+                                                                                       <div class="debug idStack">id stack: example:Observable-b650c988-aac7-45ff-967d-9f1e5fc66161,example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa</div>
+                                                                                    </div>
+                                                                                    <div class="contents associatedObjectContents associatedObject">
+                                                                                       <div class="associatedObjectDescription description">
+                                                                                          description: 
+                                                                                          This mp4 file causes memory corruption and code
+                                                                                          execution via heap-spraying code injection.
+                                                                                          
+                                                                                       </div>
+                                                                                       <div>
+                                                                                          <fieldset>
+                                                                                             <legend>
+                                                                                                cybox properties
+                                                                                                (type: FileObjectType)
+                                                                                                
+                                                                                             </legend>
+                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">File_Name</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">test.mp4</span><div class="cyboxPropertiesLink"></div>
+                                                                                                </div>
+                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                             </div>
+                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Size_In_Bytes</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">22384</span><div class="cyboxPropertiesLink"></div>
+                                                                                                </div>
+                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                             </div>
+                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Hashes</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                                      
+                                                                                                      </span><div class="cyboxPropertiesLink"></div>
+                                                                                                </div>
+                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                                   <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                      <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Hash</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                                            
+                                                                                                            
+                                                                                                            </span><div class="cyboxPropertiesLink"></div>
+                                                                                                      </div>
+                                                                                                      <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                                         <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                            <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Type</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">MD5</span><div class="cyboxPropertiesLink"></div>
+                                                                                                            </div>
+                                                                                                            <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                         </div>
+                                                                                                         <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                            <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Simple_Hash_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">8933598C8B1FA5E493497B11C48DA4F2</span><div class="cyboxPropertiesLink"></div>
+                                                                                                            </div>
+                                                                                                            <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                         </div>
+                                                                                                      </div>
+                                                                                                   </div>
+                                                                                                </div>
+                                                                                             </div>
+                                                                                          </fieldset>
+                                                                                       </div>
+                                                                                       <div class="container relatedObjects">
+                                                                                          <div class="heading relatedObjects">Related Objects
+                                                                                             
+                                                                                          </div>
+                                                                                          <div class="contents relatedObjects">
+                                                                                             <div class="container relatedObjectContainer relatedObject">
+                                                                                                <div class="heading relatedObjectHeading relatedObject">
+                                                                                                   <div class="debug idStack">id stack: example:Observable-b650c988-aac7-45ff-967d-9f1e5fc66161,example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa</div>
+                                                                                                   <div class="expandableContainer expandableSeparate collapsed">
+                                                                                                      <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Downloaded_By ○  FileObjectType ○ example:Object-49d31c13-8d7b-4528-b8d6-ce8ed0d43ad7 <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                                      <div class="expandableContents">
+                                                                                                         <div class="container associatedObjectContainer associatedObject">
+                                                                                                            <div class="heading associatedObjectHeading associatedObject">
+                                                                                                               <div class="debug idStack">id stack: example:Observable-b650c988-aac7-45ff-967d-9f1e5fc66161,example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa,example:Object-49d31c13-8d7b-4528-b8d6-ce8ed0d43ad7</div>
+                                                                                                            </div>
+                                                                                                            <div class="contents associatedObjectContents associatedObject">
+                                                                                                               <div class="associatedObjectDescription description">
+                                                                                                                  description: 
+                                                                                                                  The word document contains flash, which downloads a
+                                                                                                                  corrupted mp4 file. The mp4 file itself is not anything special
+                                                                                                                  but an 0C filled (22kb) mp4 file with a valid mp4
+                                                                                                                  header.
+                                                                                                                  
+                                                                                                               </div>
+                                                                                                               <div>
+                                                                                                                  <fieldset>
+                                                                                                                     <legend>
+                                                                                                                        cybox properties
+                                                                                                                        (type: FileObjectType)
+                                                                                                                        
+                                                                                                                     </legend>
+                                                                                                                     <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                        <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">File_Name</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">Iran's Oil and Nuclear Situation.doc</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                     </div>
+                                                                                                                     <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                        <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Size_In_Bytes</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">106604</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                     </div>
+                                                                                                                     <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                        <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Hashes</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                                                              
+                                                                                                                              </span><div class="cyboxPropertiesLink"></div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                                                           <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                              <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Hash</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                                                                    
+                                                                                                                                    
+                                                                                                                                    </span><div class="cyboxPropertiesLink"></div>
+                                                                                                                              </div>
+                                                                                                                              <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                                                                 <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                    <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Type</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">MD5</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                    </div>
+                                                                                                                                    <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                                 </div>
+                                                                                                                                 <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                    <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Simple_Hash_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">E92A4FC283EB2802AD6D0E24C7FCC857</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                    </div>
+                                                                                                                                    <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                                 </div>
+                                                                                                                              </div>
+                                                                                                                           </div>
+                                                                                                                        </div>
+                                                                                                                     </div>
+                                                                                                                  </fieldset>
+                                                                                                               </div>
+                                                                                                            </div>
+                                                                                                         </div>
+                                                                                                      </div>
+                                                                                                   </div>
+                                                                                                </div>
+                                                                                                <div class="contents relatedObjectContents relatedObject">
+                                                                                                   <div></div>
+                                                                                                </div>
+                                                                                             </div>
+                                                                                             <div class="container relatedObjectContainer relatedObject">
+                                                                                                <div class="heading relatedObjectHeading relatedObject">
+                                                                                                   <div class="debug idStack">id stack: example:Observable-b650c988-aac7-45ff-967d-9f1e5fc66161,example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa</div>
+                                                                                                   <div class="expandableContainer expandableSeparate collapsed">
+                                                                                                      <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Downloaded_From ○  URIObjectType ○ example:Object-61041b8b-0c15-48a0-ac5f-b49488788010 <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                                      <div class="expandableContents">
+                                                                                                         <div class="container associatedObjectContainer associatedObject">
+                                                                                                            <div class="heading associatedObjectHeading associatedObject">
+                                                                                                               <div class="debug idStack">id stack: example:Observable-b650c988-aac7-45ff-967d-9f1e5fc66161,example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa,example:Object-61041b8b-0c15-48a0-ac5f-b49488788010</div>
+                                                                                                            </div>
+                                                                                                            <div class="contents associatedObjectContents associatedObject">
+                                                                                                               <div>
+                                                                                                                  <fieldset>
+                                                                                                                     <legend>
+                                                                                                                        cybox properties
+                                                                                                                        (type: URIObjectType)
+                                                                                                                        <span class="cyboxPropertiesSingleConstraint"> [type=URL]</span></legend>
+                                                                                                                     <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                        <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">http://208.115.230.76/test.mp4</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                     </div>
+                                                                                                                  </fieldset>
+                                                                                                               </div>
+                                                                                                            </div>
+                                                                                                         </div>
+                                                                                                      </div>
+                                                                                                   </div>
+                                                                                                </div>
+                                                                                                <div class="contents relatedObjectContents relatedObject">
+                                                                                                   <div></div>
+                                                                                                </div>
+                                                                                             </div>
+                                                                                          </div>
+                                                                                       </div>
+                                                                                    </div>
+                                                                                 </div>
+                                                                              </div>
+                                                                           </div>
+                                                                        </div>
+                                                                        <div class="contents associatedObjectContents associatedObject">
+                                                                           <div></div>
+                                                                        </div>
+                                                                     </div>
+                                                                     <div class="container associatedObjectContainer associatedObject">
+                                                                        <div class="heading associatedObjectHeading associatedObject">
+                                                                           <div class="debug idStack">id stack: example:Observable-b650c988-aac7-45ff-967d-9f1e5fc66161</div>
+                                                                           <div class="expandableContainer expandableSeparate collapsed">
+                                                                              <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Affected ○  FileObjectType ○ example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                              <div class="expandableContents">
+                                                                                 <div class="container associatedObjectContainer associatedObject">
+                                                                                    <div class="heading associatedObjectHeading associatedObject">
+                                                                                       <div class="debug idStack">id stack: example:Observable-b650c988-aac7-45ff-967d-9f1e5fc66161,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c</div>
+                                                                                    </div>
+                                                                                    <div class="contents associatedObjectContents associatedObject">
+                                                                                       <div class="associatedObjectDescription description">
+                                                                                          description: 
+                                                                                          The file (us.exe MD5: FD1BE09E499E8E380424B3835FC973A8
+                                                                                          4861440 bytes) is created in the logged in user %Temp%
+                                                                                          directory. The size of the embedded file is 22.5 KB (23040
+                                                                                          bytes) and the size of the created us.exe is 4.63MB. It is an
+                                                                                          odd discrepancy until you look at the file and it looks like the
+                                                                                          code is repeated over and over - 211 times. The file resource
+                                                                                          section indicates the file is meant to look like a java updater,
+                                                                                          which is always larger than 22.5KB and that would explain all
+                                                                                          this padding, which is done at the time when the file is being
+                                                                                          written to the disk.
+                                                                                          
+                                                                                       </div>
+                                                                                       <div>
+                                                                                          <fieldset>
+                                                                                             <legend>
+                                                                                                cybox properties
+                                                                                                (type: FileObjectType)
+                                                                                                
+                                                                                             </legend>
+                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">File_Name</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">us.exe</span><div class="cyboxPropertiesLink"></div>
+                                                                                                </div>
+                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                             </div>
+                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">File_Path</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">%Temp%</span><div class="cyboxPropertiesLink"></div>
+                                                                                                </div>
+                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                             </div>
+                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Size_In_Bytes</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">4861440</span><div class="cyboxPropertiesLink"></div>
+                                                                                                </div>
+                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                             </div>
+                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Hashes</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                                      
+                                                                                                      </span><div class="cyboxPropertiesLink"></div>
+                                                                                                </div>
+                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                                   <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                      <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Hash</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                                            
+                                                                                                            
+                                                                                                            </span><div class="cyboxPropertiesLink"></div>
+                                                                                                      </div>
+                                                                                                      <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                                         <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                            <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Type</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">MD5</span><div class="cyboxPropertiesLink"></div>
+                                                                                                            </div>
+                                                                                                            <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                         </div>
+                                                                                                         <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                            <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Simple_Hash_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">FD1BE09E499E8E380424B3835FC973A8</span><div class="cyboxPropertiesLink"></div>
+                                                                                                            </div>
+                                                                                                            <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                         </div>
+                                                                                                      </div>
+                                                                                                   </div>
+                                                                                                </div>
+                                                                                             </div>
+                                                                                          </fieldset>
+                                                                                       </div>
+                                                                                       <div class="container relatedObjects">
+                                                                                          <div class="heading relatedObjects">Related Objects
+                                                                                             
+                                                                                          </div>
+                                                                                          <div class="contents relatedObjects">
+                                                                                             <div class="container relatedObjectContainer relatedObject">
+                                                                                                <div class="heading relatedObjectHeading relatedObject">
+                                                                                                   <div class="debug idStack">id stack: example:Observable-b650c988-aac7-45ff-967d-9f1e5fc66161,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c</div>
+                                                                                                   <div class="expandableContainer expandableSeparate collapsed">
+                                                                                                      <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Created_By ○  FileObjectType ○ example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                                      <div class="expandableContents">
+                                                                                                         <div class="container associatedObjectContainer associatedObject">
+                                                                                                            <div class="heading associatedObjectHeading associatedObject">
+                                                                                                               <div class="debug idStack">id stack: example:Observable-b650c988-aac7-45ff-967d-9f1e5fc66161,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa</div>
+                                                                                                            </div>
+                                                                                                            <div class="contents associatedObjectContents associatedObject">
+                                                                                                               <div class="associatedObjectDescription description">
+                                                                                                                  description: 
+                                                                                                                  This mp4 file causes memory corruption and code
+                                                                                                                  execution via heap-spraying code injection.
+                                                                                                                  
+                                                                                                               </div>
+                                                                                                               <div>
+                                                                                                                  <fieldset>
+                                                                                                                     <legend>
+                                                                                                                        cybox properties
+                                                                                                                        (type: FileObjectType)
+                                                                                                                        
+                                                                                                                     </legend>
+                                                                                                                     <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                        <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">File_Name</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">test.mp4</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                     </div>
+                                                                                                                     <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                        <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Size_In_Bytes</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">22384</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                     </div>
+                                                                                                                     <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                        <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Hashes</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                                                              
+                                                                                                                              </span><div class="cyboxPropertiesLink"></div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                                                           <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                              <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Hash</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                                                                    
+                                                                                                                                    
+                                                                                                                                    </span><div class="cyboxPropertiesLink"></div>
+                                                                                                                              </div>
+                                                                                                                              <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                                                                 <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                    <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Type</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">MD5</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                    </div>
+                                                                                                                                    <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                                 </div>
+                                                                                                                                 <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                    <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Simple_Hash_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">8933598C8B1FA5E493497B11C48DA4F2</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                    </div>
+                                                                                                                                    <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                                 </div>
+                                                                                                                              </div>
+                                                                                                                           </div>
+                                                                                                                        </div>
+                                                                                                                     </div>
+                                                                                                                  </fieldset>
+                                                                                                               </div>
+                                                                                                               <div class="container relatedObjects">
+                                                                                                                  <div class="heading relatedObjects">Related Objects
+                                                                                                                     
+                                                                                                                  </div>
+                                                                                                                  <div class="contents relatedObjects">
+                                                                                                                     <div class="container relatedObjectContainer relatedObject">
+                                                                                                                        <div class="heading relatedObjectHeading relatedObject">
+                                                                                                                           <div class="debug idStack">id stack: example:Observable-b650c988-aac7-45ff-967d-9f1e5fc66161,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa</div>
+                                                                                                                           <div class="expandableContainer expandableSeparate collapsed">
+                                                                                                                              <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Downloaded_By ○  FileObjectType ○ example:Object-49d31c13-8d7b-4528-b8d6-ce8ed0d43ad7 <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                                                              <div class="expandableContents">
+                                                                                                                                 <div class="container associatedObjectContainer associatedObject">
+                                                                                                                                    <div class="heading associatedObjectHeading associatedObject">
+                                                                                                                                       <div class="debug idStack">id stack: example:Observable-b650c988-aac7-45ff-967d-9f1e5fc66161,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa,example:Object-49d31c13-8d7b-4528-b8d6-ce8ed0d43ad7</div>
+                                                                                                                                    </div>
+                                                                                                                                    <div class="contents associatedObjectContents associatedObject">
+                                                                                                                                       <div class="associatedObjectDescription description">
+                                                                                                                                          description: 
+                                                                                                                                          The word document contains flash, which downloads a
+                                                                                                                                          corrupted mp4 file. The mp4 file itself is not anything special
+                                                                                                                                          but an 0C filled (22kb) mp4 file with a valid mp4
+                                                                                                                                          header.
+                                                                                                                                          
+                                                                                                                                       </div>
+                                                                                                                                       <div>
+                                                                                                                                          <fieldset>
+                                                                                                                                             <legend>
+                                                                                                                                                cybox properties
+                                                                                                                                                (type: FileObjectType)
+                                                                                                                                                
+                                                                                                                                             </legend>
+                                                                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">File_Name</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">Iran's Oil and Nuclear Situation.doc</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                                </div>
+                                                                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                                             </div>
+                                                                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Size_In_Bytes</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">106604</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                                </div>
+                                                                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                                             </div>
+                                                                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Hashes</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                                                                                      
+                                                                                                                                                      </span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                                </div>
+                                                                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                                                                                   <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                                      <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Hash</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                                                                                            
+                                                                                                                                                            
+                                                                                                                                                            </span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                                      </div>
+                                                                                                                                                      <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                                                                                         <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                                            <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Type</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">MD5</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                                            </div>
+                                                                                                                                                            <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                                                         </div>
+                                                                                                                                                         <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                                            <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Simple_Hash_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">E92A4FC283EB2802AD6D0E24C7FCC857</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                                            </div>
+                                                                                                                                                            <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                                                         </div>
+                                                                                                                                                      </div>
+                                                                                                                                                   </div>
+                                                                                                                                                </div>
+                                                                                                                                             </div>
+                                                                                                                                          </fieldset>
+                                                                                                                                       </div>
+                                                                                                                                    </div>
+                                                                                                                                 </div>
+                                                                                                                              </div>
+                                                                                                                           </div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents relatedObjectContents relatedObject">
+                                                                                                                           <div></div>
+                                                                                                                        </div>
+                                                                                                                     </div>
+                                                                                                                     <div class="container relatedObjectContainer relatedObject">
+                                                                                                                        <div class="heading relatedObjectHeading relatedObject">
+                                                                                                                           <div class="debug idStack">id stack: example:Observable-b650c988-aac7-45ff-967d-9f1e5fc66161,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa</div>
+                                                                                                                           <div class="expandableContainer expandableSeparate collapsed">
+                                                                                                                              <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Downloaded_From ○  URIObjectType ○ example:Object-61041b8b-0c15-48a0-ac5f-b49488788010 <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                                                              <div class="expandableContents">
+                                                                                                                                 <div class="container associatedObjectContainer associatedObject">
+                                                                                                                                    <div class="heading associatedObjectHeading associatedObject">
+                                                                                                                                       <div class="debug idStack">id stack: example:Observable-b650c988-aac7-45ff-967d-9f1e5fc66161,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa,example:Object-61041b8b-0c15-48a0-ac5f-b49488788010</div>
+                                                                                                                                    </div>
+                                                                                                                                    <div class="contents associatedObjectContents associatedObject">
+                                                                                                                                       <div>
+                                                                                                                                          <fieldset>
+                                                                                                                                             <legend>
+                                                                                                                                                cybox properties
+                                                                                                                                                (type: URIObjectType)
+                                                                                                                                                <span class="cyboxPropertiesSingleConstraint"> [type=URL]</span></legend>
+                                                                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">http://208.115.230.76/test.mp4</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                                </div>
+                                                                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                                             </div>
+                                                                                                                                          </fieldset>
+                                                                                                                                       </div>
+                                                                                                                                    </div>
+                                                                                                                                 </div>
+                                                                                                                              </div>
+                                                                                                                           </div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents relatedObjectContents relatedObject">
+                                                                                                                           <div></div>
+                                                                                                                        </div>
+                                                                                                                     </div>
+                                                                                                                  </div>
+                                                                                                               </div>
+                                                                                                            </div>
+                                                                                                         </div>
+                                                                                                      </div>
+                                                                                                   </div>
+                                                                                                </div>
+                                                                                                <div class="contents relatedObjectContents relatedObject">
+                                                                                                   <div></div>
+                                                                                                </div>
+                                                                                             </div>
+                                                                                             <div class="container relatedObjectContainer relatedObject">
+                                                                                                <div class="heading relatedObjectHeading relatedObject">
+                                                                                                   <div class="debug idStack">id stack: example:Observable-b650c988-aac7-45ff-967d-9f1e5fc66161,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c</div>
+                                                                                                   <div class="expandableContainer expandableSeparate collapsed">
+                                                                                                      <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Connected_To ○  URIObjectType ○ example:Object-41b220d8-4c45-48de-9d08-30d661b2dc8e <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                                      <div class="expandableContents">
+                                                                                                         <div class="container objectContainer object">
+                                                                                                            <div class="heading objectHeading object">
+                                                                                                               <div class="debug idStack">id stack: example:Observable-b650c988-aac7-45ff-967d-9f1e5fc66161,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-41b220d8-4c45-48de-9d08-30d661b2dc8e</div>
+                                                                                                            </div>
+                                                                                                            <div class="contents objectContents object">
+                                                                                                               <div>
+                                                                                                                  <fieldset>
+                                                                                                                     <legend>
+                                                                                                                        cybox properties
+                                                                                                                        (type: URIObjectType)
+                                                                                                                        
+                                                                                                                     </legend>
+                                                                                                                     <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                        <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">www.documents.myPicture.info</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                     </div>
+                                                                                                                  </fieldset>
+                                                                                                               </div>
+                                                                                                               <div class="container relatedObjects">
+                                                                                                                  <div class="heading relatedObjects">Related Objects
+                                                                                                                     
+                                                                                                                  </div>
+                                                                                                                  <div class="contents relatedObjects">
+                                                                                                                     <div class="container relatedObjectContainer relatedObject">
+                                                                                                                        <div class="heading relatedObjectHeading relatedObject">
+                                                                                                                           <div class="debug idStack">id stack: example:Observable-b650c988-aac7-45ff-967d-9f1e5fc66161,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-41b220d8-4c45-48de-9d08-30d661b2dc8e</div>
+                                                                                                                           <div class="expandableContainer expandableSeparate collapsed">
+                                                                                                                              <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Resolved_To ○  AddressObjectType ○ example:Object-61aa225b-90ef-415c-8bbd-a17282e457c9 <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                                                              <div class="expandableContents">
+                                                                                                                                 <div class="container objectContainer object">
+                                                                                                                                    <div class="heading objectHeading object">
+                                                                                                                                       <div class="debug idStack">id stack: example:Observable-b650c988-aac7-45ff-967d-9f1e5fc66161,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-41b220d8-4c45-48de-9d08-30d661b2dc8e,example:Object-61aa225b-90ef-415c-8bbd-a17282e457c9</div>
+                                                                                                                                    </div>
+                                                                                                                                    <div class="contents objectContents object">
+                                                                                                                                       <div>
+                                                                                                                                          <fieldset>
+                                                                                                                                             <legend>
+                                                                                                                                                cybox properties
+                                                                                                                                                (type: AddressObjectType)
+                                                                                                                                                <span class="cyboxPropertiesSingleConstraint"> [category=ipv4-addr]</span></legend>
+                                                                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Address_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">199.192.156.134</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                                </div>
+                                                                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                                             </div>
+                                                                                                                                          </fieldset>
+                                                                                                                                       </div>
+                                                                                                                                    </div>
+                                                                                                                                 </div>
+                                                                                                                              </div>
+                                                                                                                           </div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents relatedObjectContents relatedObject">
+                                                                                                                           <div></div>
+                                                                                                                        </div>
+                                                                                                                     </div>
+                                                                                                                  </div>
+                                                                                                               </div>
+                                                                                                            </div>
+                                                                                                         </div>
+                                                                                                      </div>
+                                                                                                   </div>
+                                                                                                </div>
+                                                                                                <div class="contents relatedObjectContents relatedObject">
+                                                                                                   <div></div>
+                                                                                                </div>
+                                                                                             </div>
+                                                                                             <div class="container relatedObjectContainer relatedObject">
+                                                                                                <div class="heading relatedObjectHeading relatedObject">
+                                                                                                   <div class="debug idStack">id stack: example:Observable-b650c988-aac7-45ff-967d-9f1e5fc66161,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c</div>
+                                                                                                   <div class="expandableContainer expandableSeparate collapsed">
+                                                                                                      <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Connected_To ○  AddressObjectType ○ example:Object-61aa225b-90ef-415c-8bbd-a17282e457c9 <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                                      <div class="expandableContents">
+                                                                                                         <div class="container objectContainer object">
+                                                                                                            <div class="heading objectHeading object">
+                                                                                                               <div class="debug idStack">id stack: example:Observable-b650c988-aac7-45ff-967d-9f1e5fc66161,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-61aa225b-90ef-415c-8bbd-a17282e457c9</div>
+                                                                                                            </div>
+                                                                                                            <div class="contents objectContents object">
+                                                                                                               <div>
+                                                                                                                  <fieldset>
+                                                                                                                     <legend>
+                                                                                                                        cybox properties
+                                                                                                                        (type: AddressObjectType)
+                                                                                                                        <span class="cyboxPropertiesSingleConstraint"> [category=ipv4-addr]</span></legend>
+                                                                                                                     <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                        <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Address_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">199.192.156.134</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                     </div>
+                                                                                                                  </fieldset>
+                                                                                                               </div>
+                                                                                                            </div>
+                                                                                                         </div>
+                                                                                                      </div>
+                                                                                                   </div>
+                                                                                                </div>
+                                                                                                <div class="contents relatedObjectContents relatedObject">
+                                                                                                   <div></div>
+                                                                                                </div>
+                                                                                             </div>
+                                                                                             <div class="container relatedObjectContainer relatedObject">
+                                                                                                <div class="heading relatedObjectHeading relatedObject">
+                                                                                                   <div class="debug idStack">id stack: example:Observable-b650c988-aac7-45ff-967d-9f1e5fc66161,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c</div>
+                                                                                                   <div class="expandableContainer expandableSeparate collapsed">
+                                                                                                      <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Connected_To ○  URIObjectType ○ example:Object-568db11e-39ee-43d7-83d8-032bdec3801a <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                                      <div class="expandableContents">
+                                                                                                         <div class="container objectContainer object">
+                                                                                                            <div class="heading objectHeading object">
+                                                                                                               <div class="debug idStack">id stack: example:Observable-b650c988-aac7-45ff-967d-9f1e5fc66161,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-568db11e-39ee-43d7-83d8-032bdec3801a</div>
+                                                                                                            </div>
+                                                                                                            <div class="contents objectContents object">
+                                                                                                               <div>
+                                                                                                                  <fieldset>
+                                                                                                                     <legend>
+                                                                                                                        cybox properties
+                                                                                                                        (type: URIObjectType)
+                                                                                                                        <span class="cyboxPropertiesSingleConstraint"> [type=URL]</span></legend>
+                                                                                                                     <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                        <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">documents.myPicture.info</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                     </div>
+                                                                                                                  </fieldset>
+                                                                                                               </div>
+                                                                                                               <div class="container relatedObjects">
+                                                                                                                  <div class="heading relatedObjects">Related Objects
+                                                                                                                     
+                                                                                                                  </div>
+                                                                                                                  <div class="contents relatedObjects">
+                                                                                                                     <div class="container relatedObjectContainer relatedObject">
+                                                                                                                        <div class="heading relatedObjectHeading relatedObject">
+                                                                                                                           <div class="debug idStack">id stack: example:Observable-b650c988-aac7-45ff-967d-9f1e5fc66161,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-568db11e-39ee-43d7-83d8-032bdec3801a</div>
+                                                                                                                           <div class="expandableContainer expandableSeparate collapsed">
+                                                                                                                              <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Resolved_To ○  AddressObjectType ○ example:Object-80bea4d1-0e70-4a03-a54f-e40373bf94f1 <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                                                              <div class="expandableContents">
+                                                                                                                                 <div class="container objectContainer object">
+                                                                                                                                    <div class="heading objectHeading object">
+                                                                                                                                       <div class="debug idStack">id stack: example:Observable-b650c988-aac7-45ff-967d-9f1e5fc66161,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-568db11e-39ee-43d7-83d8-032bdec3801a,example:Object-80bea4d1-0e70-4a03-a54f-e40373bf94f1</div>
+                                                                                                                                    </div>
+                                                                                                                                    <div class="contents objectContents object">
+                                                                                                                                       <div>
+                                                                                                                                          <fieldset>
+                                                                                                                                             <legend>
+                                                                                                                                                cybox properties
+                                                                                                                                                (type: AddressObjectType)
+                                                                                                                                                <span class="cyboxPropertiesSingleConstraint"> [category=ipv4-addr]</span></legend>
+                                                                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Address_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">199.192.156.134</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                                </div>
+                                                                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                                             </div>
+                                                                                                                                          </fieldset>
+                                                                                                                                       </div>
+                                                                                                                                    </div>
+                                                                                                                                 </div>
+                                                                                                                              </div>
+                                                                                                                           </div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents relatedObjectContents relatedObject">
+                                                                                                                           <div></div>
+                                                                                                                        </div>
+                                                                                                                     </div>
+                                                                                                                  </div>
+                                                                                                               </div>
+                                                                                                            </div>
+                                                                                                         </div>
+                                                                                                      </div>
+                                                                                                   </div>
+                                                                                                </div>
+                                                                                                <div class="contents relatedObjectContents relatedObject">
+                                                                                                   <div></div>
+                                                                                                </div>
+                                                                                             </div>
+                                                                                             <div class="container relatedObjectContainer relatedObject">
+                                                                                                <div class="heading relatedObjectHeading relatedObject">
+                                                                                                   <div class="debug idStack">id stack: example:Observable-b650c988-aac7-45ff-967d-9f1e5fc66161,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c</div>
+                                                                                                   <div class="expandableContainer expandableSeparate collapsed">
+                                                                                                      <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Connected_To ○  AddressObjectType ○ example:Object-80bea4d1-0e70-4a03-a54f-e40373bf94f1 <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                                      <div class="expandableContents">
+                                                                                                         <div class="container objectContainer object">
+                                                                                                            <div class="heading objectHeading object">
+                                                                                                               <div class="debug idStack">id stack: example:Observable-b650c988-aac7-45ff-967d-9f1e5fc66161,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-80bea4d1-0e70-4a03-a54f-e40373bf94f1</div>
+                                                                                                            </div>
+                                                                                                            <div class="contents objectContents object">
+                                                                                                               <div>
+                                                                                                                  <fieldset>
+                                                                                                                     <legend>
+                                                                                                                        cybox properties
+                                                                                                                        (type: AddressObjectType)
+                                                                                                                        <span class="cyboxPropertiesSingleConstraint"> [category=ipv4-addr]</span></legend>
+                                                                                                                     <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                        <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Address_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">199.192.156.134</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                     </div>
+                                                                                                                  </fieldset>
+                                                                                                               </div>
+                                                                                                            </div>
+                                                                                                         </div>
+                                                                                                      </div>
+                                                                                                   </div>
+                                                                                                </div>
+                                                                                                <div class="contents relatedObjectContents relatedObject">
+                                                                                                   <div></div>
+                                                                                                </div>
+                                                                                             </div>
+                                                                                             <div class="container relatedObjectContainer relatedObject">
+                                                                                                <div class="heading relatedObjectHeading relatedObject">
+                                                                                                   <div class="debug idStack">id stack: example:Observable-b650c988-aac7-45ff-967d-9f1e5fc66161,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c</div>
+                                                                                                   <div class="expandableContainer expandableSeparate collapsed">
+                                                                                                      <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Connected_To ○  URIObjectType ○ example:Object-af7cb3b6-d70b-4b3b-b24f-7cfad739710f <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                                      <div class="expandableContents">
+                                                                                                         <div class="container objectContainer object">
+                                                                                                            <div class="heading objectHeading object">
+                                                                                                               <div class="debug idStack">id stack: example:Observable-b650c988-aac7-45ff-967d-9f1e5fc66161,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-af7cb3b6-d70b-4b3b-b24f-7cfad739710f</div>
+                                                                                                            </div>
+                                                                                                            <div class="contents objectContents object">
+                                                                                                               <div>
+                                                                                                                  <fieldset>
+                                                                                                                     <legend>
+                                                                                                                        cybox properties
+                                                                                                                        (type: URIObjectType)
+                                                                                                                        <span class="cyboxPropertiesSingleConstraint"> [type=URL]</span></legend>
+                                                                                                                     <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                        <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">ftp.documents.myPicture.info</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                     </div>
+                                                                                                                  </fieldset>
+                                                                                                               </div>
+                                                                                                               <div class="container relatedObjects">
+                                                                                                                  <div class="heading relatedObjects">Related Objects
+                                                                                                                     
+                                                                                                                  </div>
+                                                                                                                  <div class="contents relatedObjects">
+                                                                                                                     <div class="container relatedObjectContainer relatedObject">
+                                                                                                                        <div class="heading relatedObjectHeading relatedObject">
+                                                                                                                           <div class="debug idStack">id stack: example:Observable-b650c988-aac7-45ff-967d-9f1e5fc66161,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-af7cb3b6-d70b-4b3b-b24f-7cfad739710f</div>
+                                                                                                                           <div class="expandableContainer expandableSeparate collapsed">
+                                                                                                                              <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Resolved_To ○  AddressObjectType ○ example:Object-5ceb9d54-24e2-4627-948d-6b92ac81962a <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                                                              <div class="expandableContents">
+                                                                                                                                 <div class="container objectContainer object">
+                                                                                                                                    <div class="heading objectHeading object">
+                                                                                                                                       <div class="debug idStack">id stack: example:Observable-b650c988-aac7-45ff-967d-9f1e5fc66161,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-af7cb3b6-d70b-4b3b-b24f-7cfad739710f,example:Object-5ceb9d54-24e2-4627-948d-6b92ac81962a</div>
+                                                                                                                                    </div>
+                                                                                                                                    <div class="contents objectContents object">
+                                                                                                                                       <div>
+                                                                                                                                          <fieldset>
+                                                                                                                                             <legend>
+                                                                                                                                                cybox properties
+                                                                                                                                                (type: AddressObjectType)
+                                                                                                                                                <span class="cyboxPropertiesSingleConstraint"> [category=ipv4-addr]</span></legend>
+                                                                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Address_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">199.192.156.134</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                                </div>
+                                                                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                                             </div>
+                                                                                                                                          </fieldset>
+                                                                                                                                       </div>
+                                                                                                                                    </div>
+                                                                                                                                 </div>
+                                                                                                                              </div>
+                                                                                                                           </div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents relatedObjectContents relatedObject">
+                                                                                                                           <div></div>
+                                                                                                                        </div>
+                                                                                                                     </div>
+                                                                                                                  </div>
+                                                                                                               </div>
+                                                                                                            </div>
+                                                                                                         </div>
+                                                                                                      </div>
+                                                                                                   </div>
+                                                                                                </div>
+                                                                                                <div class="contents relatedObjectContents relatedObject">
+                                                                                                   <div></div>
+                                                                                                </div>
+                                                                                             </div>
+                                                                                             <div class="container relatedObjectContainer relatedObject">
+                                                                                                <div class="heading relatedObjectHeading relatedObject">
+                                                                                                   <div class="debug idStack">id stack: example:Observable-b650c988-aac7-45ff-967d-9f1e5fc66161,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c</div>
+                                                                                                   <div class="objectReference nonexpandableContainer"> <span class="externalLinkWarning">[external]</span>  ○ example:guid-5ceb9d54-24e2-4627-948d-6b92ac81962a <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                                </div>
+                                                                                                <div class="contents relatedObjectContents relatedObject">
+                                                                                                   <div></div>
+                                                                                                </div>
+                                                                                             </div>
+                                                                                          </div>
+                                                                                       </div>
+                                                                                    </div>
+                                                                                 </div>
+                                                                              </div>
+                                                                           </div>
+                                                                        </div>
+                                                                        <div class="contents associatedObjectContents associatedObject">
+                                                                           <div></div>
+                                                                        </div>
+                                                                     </div>
+                                                                  </div>
+                                                               </div>
+                                                            </div>
+                                                         </div>
+                                                      </div>
+                                                   </div>
+                                                   <div></div>
+                                                </div>
+                                             </div>
+                                          </td>
+                                       </tr>
+                                    </tbody>
+                                 </table>
+                              </div>
+                           </div>
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR style="width:100%;font-style:italic;">
+                     <TD colspan="2">
+                        <div style="font-size:13px; font-style: italic; display:none;" id="6_ind_description">Test Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!! Test
+                           Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre
+                           Artifact Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre Artifact
+                           Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!!
+                           Test Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!! Test
+                           Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre
+                           Artifact Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre Artifact
+                           Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!!
+                           Test Malwawre Artifact Information!!!! 
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR class="">
+                     <TD>
+                        <div id="fileObjAtt" class="collapsibleLabel" style="cursor: pointer;" onclick="toggleDiv('700000000436','d1e445','d1e445-2')"><span id="d1e445" style="font-weight:bold; margin:5px; color:#BD9C8C;">+</span>example:Observable-dee72b3e-82fb-4319-bfcc-007e3cf930e8
+                        </div>
+                     </TD>
+                     <TD>
+                        <div style="cursor: pointer;" onclick="toggleDiv('700000000436','d1e445','d1e445-2')"><span id="d1e445-2" style="font-weight:bold; margin:5px; color:#BD9C8C;">+</span>FileObjectType
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR class="">
+                     <TD colspan="2">
+                        <div id="700000000436" class="collapsibleContent" style="overflow:hidden; display:none; padding:0px 7px;">
+                           <div id="example:Observable-dee72b3e-82fb-4319-bfcc-007e3cf930e8">
+                              <div class="debug idStack">id stack: example:Observable-dee72b3e-82fb-4319-bfcc-007e3cf930e8</div><br><div id="section">
+                                 <table class="one-column-emphasis">
+                                    <colgroup>
+                                       <col class="oce-first-obs">
+                                    </colgroup>
+                                    <tbody>
+                                       <tr>
+                                          <td>
+                                             <div class="container objectContainer object" id="example:Object-bed1ff22-08e8-4e04-b7ac-908b5271176f">
+                                                <div class="heading objectHeading object"> FileObjectType ○ <span class="inlineObject">example:Object-bed1ff22-08e8-4e04-b7ac-908b5271176f</span> <span class="debug inlineOrByReferenceLabel">(inline object)</span><div class="debug idStack">id stack: example:Observable-dee72b3e-82fb-4319-bfcc-007e3cf930e8,example:Object-bed1ff22-08e8-4e04-b7ac-908b5271176f</div>
+                                                </div>
+                                                <div class="contents objectContents object">
+                                                   <div>
+                                                      <fieldset>
+                                                         <legend>
+                                                            cybox properties
+                                                            (type: FileObjectType)
+                                                            
+                                                         </legend>
+                                                         <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                            <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">File_Name</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">us-embedded.exe</span><div class="cyboxPropertiesLink"></div>
+                                                            </div>
+                                                            <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                         </div>
+                                                         <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                            <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Size_In_Bytes</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">23040</span><div class="cyboxPropertiesLink"></div>
+                                                            </div>
+                                                            <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                         </div>
+                                                         <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                            <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Hashes</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                  
+                                                                  </span><div class="cyboxPropertiesLink"></div>
+                                                            </div>
+                                                            <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                               <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                  <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Hash</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                        
+                                                                        
+                                                                        </span><div class="cyboxPropertiesLink"></div>
+                                                                  </div>
+                                                                  <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                     <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                        <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Type</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">MD5</span><div class="cyboxPropertiesLink"></div>
+                                                                        </div>
+                                                                        <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                     </div>
+                                                                     <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                        <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Simple_Hash_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">CB3DCDE34FD9FF0E19381D99B02F9692</span><div class="cyboxPropertiesLink"></div>
+                                                                        </div>
+                                                                        <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                     </div>
+                                                                  </div>
+                                                               </div>
+                                                            </div>
+                                                         </div>
+                                                      </fieldset>
+                                                   </div>
+                                                   <div class="container relatedObjects">
+                                                      <div class="heading relatedObjects">Related Objects
+                                                         
+                                                      </div>
+                                                      <div class="contents relatedObjects">
+                                                         <div class="container relatedObjectContainer relatedObject">
+                                                            <div class="heading relatedObjectHeading relatedObject">
+                                                               <div class="debug idStack">id stack: example:Observable-dee72b3e-82fb-4319-bfcc-007e3cf930e8,example:Object-bed1ff22-08e8-4e04-b7ac-908b5271176f</div>
+                                                               <div class="expandableContainer expandableSeparate collapsed">
+                                                                  <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Contained_Within ○  FileObjectType ○ example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                  <div class="expandableContents">
+                                                                     <div class="container associatedObjectContainer associatedObject">
+                                                                        <div class="heading associatedObjectHeading associatedObject">
+                                                                           <div class="debug idStack">id stack: example:Observable-dee72b3e-82fb-4319-bfcc-007e3cf930e8,example:Object-bed1ff22-08e8-4e04-b7ac-908b5271176f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c</div>
+                                                                        </div>
+                                                                        <div class="contents associatedObjectContents associatedObject">
+                                                                           <div class="associatedObjectDescription description">
+                                                                              description: 
+                                                                              The file (us.exe MD5: FD1BE09E499E8E380424B3835FC973A8
+                                                                              4861440 bytes) is created in the logged in user %Temp%
+                                                                              directory. The size of the embedded file is 22.5 KB (23040
+                                                                              bytes) and the size of the created us.exe is 4.63MB. It is an
+                                                                              odd discrepancy until you look at the file and it looks like the
+                                                                              code is repeated over and over - 211 times. The file resource
+                                                                              section indicates the file is meant to look like a java updater,
+                                                                              which is always larger than 22.5KB and that would explain all
+                                                                              this padding, which is done at the time when the file is being
+                                                                              written to the disk.
+                                                                              
+                                                                           </div>
+                                                                           <div>
+                                                                              <fieldset>
+                                                                                 <legend>
+                                                                                    cybox properties
+                                                                                    (type: FileObjectType)
+                                                                                    
+                                                                                 </legend>
+                                                                                 <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                    <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">File_Name</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">us.exe</span><div class="cyboxPropertiesLink"></div>
+                                                                                    </div>
+                                                                                    <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                 </div>
+                                                                                 <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                    <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">File_Path</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">%Temp%</span><div class="cyboxPropertiesLink"></div>
+                                                                                    </div>
+                                                                                    <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                 </div>
+                                                                                 <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                    <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Size_In_Bytes</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">4861440</span><div class="cyboxPropertiesLink"></div>
+                                                                                    </div>
+                                                                                    <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                 </div>
+                                                                                 <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                    <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Hashes</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                          
+                                                                                          </span><div class="cyboxPropertiesLink"></div>
+                                                                                    </div>
+                                                                                    <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                       <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                          <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Hash</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                                
+                                                                                                
+                                                                                                </span><div class="cyboxPropertiesLink"></div>
+                                                                                          </div>
+                                                                                          <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Type</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">MD5</span><div class="cyboxPropertiesLink"></div>
+                                                                                                </div>
+                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                             </div>
+                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Simple_Hash_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">FD1BE09E499E8E380424B3835FC973A8</span><div class="cyboxPropertiesLink"></div>
+                                                                                                </div>
+                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                             </div>
+                                                                                          </div>
+                                                                                       </div>
+                                                                                    </div>
+                                                                                 </div>
+                                                                              </fieldset>
+                                                                           </div>
+                                                                           <div class="container relatedObjects">
+                                                                              <div class="heading relatedObjects">Related Objects
+                                                                                 
+                                                                              </div>
+                                                                              <div class="contents relatedObjects">
+                                                                                 <div class="container relatedObjectContainer relatedObject">
+                                                                                    <div class="heading relatedObjectHeading relatedObject">
+                                                                                       <div class="debug idStack">id stack: example:Observable-dee72b3e-82fb-4319-bfcc-007e3cf930e8,example:Object-bed1ff22-08e8-4e04-b7ac-908b5271176f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c</div>
+                                                                                       <div class="expandableContainer expandableSeparate collapsed">
+                                                                                          <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Created_By ○  FileObjectType ○ example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                          <div class="expandableContents">
+                                                                                             <div class="container associatedObjectContainer associatedObject">
+                                                                                                <div class="heading associatedObjectHeading associatedObject">
+                                                                                                   <div class="debug idStack">id stack: example:Observable-dee72b3e-82fb-4319-bfcc-007e3cf930e8,example:Object-bed1ff22-08e8-4e04-b7ac-908b5271176f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa</div>
+                                                                                                </div>
+                                                                                                <div class="contents associatedObjectContents associatedObject">
+                                                                                                   <div class="associatedObjectDescription description">
+                                                                                                      description: 
+                                                                                                      This mp4 file causes memory corruption and code
+                                                                                                      execution via heap-spraying code injection.
+                                                                                                      
+                                                                                                   </div>
+                                                                                                   <div>
+                                                                                                      <fieldset>
+                                                                                                         <legend>
+                                                                                                            cybox properties
+                                                                                                            (type: FileObjectType)
+                                                                                                            
+                                                                                                         </legend>
+                                                                                                         <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                            <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">File_Name</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">test.mp4</span><div class="cyboxPropertiesLink"></div>
+                                                                                                            </div>
+                                                                                                            <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                         </div>
+                                                                                                         <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                            <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Size_In_Bytes</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">22384</span><div class="cyboxPropertiesLink"></div>
+                                                                                                            </div>
+                                                                                                            <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                         </div>
+                                                                                                         <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                            <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Hashes</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                                                  
+                                                                                                                  </span><div class="cyboxPropertiesLink"></div>
+                                                                                                            </div>
+                                                                                                            <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                                               <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                  <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Hash</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        </span><div class="cyboxPropertiesLink"></div>
+                                                                                                                  </div>
+                                                                                                                  <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                                                     <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                        <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Type</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">MD5</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                     </div>
+                                                                                                                     <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                        <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Simple_Hash_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">8933598C8B1FA5E493497B11C48DA4F2</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                     </div>
+                                                                                                                  </div>
+                                                                                                               </div>
+                                                                                                            </div>
+                                                                                                         </div>
+                                                                                                      </fieldset>
+                                                                                                   </div>
+                                                                                                   <div class="container relatedObjects">
+                                                                                                      <div class="heading relatedObjects">Related Objects
+                                                                                                         
+                                                                                                      </div>
+                                                                                                      <div class="contents relatedObjects">
+                                                                                                         <div class="container relatedObjectContainer relatedObject">
+                                                                                                            <div class="heading relatedObjectHeading relatedObject">
+                                                                                                               <div class="debug idStack">id stack: example:Observable-dee72b3e-82fb-4319-bfcc-007e3cf930e8,example:Object-bed1ff22-08e8-4e04-b7ac-908b5271176f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa</div>
+                                                                                                               <div class="expandableContainer expandableSeparate collapsed">
+                                                                                                                  <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Downloaded_By ○  FileObjectType ○ example:Object-49d31c13-8d7b-4528-b8d6-ce8ed0d43ad7 <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                                                  <div class="expandableContents">
+                                                                                                                     <div class="container associatedObjectContainer associatedObject">
+                                                                                                                        <div class="heading associatedObjectHeading associatedObject">
+                                                                                                                           <div class="debug idStack">id stack: example:Observable-dee72b3e-82fb-4319-bfcc-007e3cf930e8,example:Object-bed1ff22-08e8-4e04-b7ac-908b5271176f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa,example:Object-49d31c13-8d7b-4528-b8d6-ce8ed0d43ad7</div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents associatedObjectContents associatedObject">
+                                                                                                                           <div class="associatedObjectDescription description">
+                                                                                                                              description: 
+                                                                                                                              The word document contains flash, which downloads a
+                                                                                                                              corrupted mp4 file. The mp4 file itself is not anything special
+                                                                                                                              but an 0C filled (22kb) mp4 file with a valid mp4
+                                                                                                                              header.
+                                                                                                                              
+                                                                                                                           </div>
+                                                                                                                           <div>
+                                                                                                                              <fieldset>
+                                                                                                                                 <legend>
+                                                                                                                                    cybox properties
+                                                                                                                                    (type: FileObjectType)
+                                                                                                                                    
+                                                                                                                                 </legend>
+                                                                                                                                 <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                    <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">File_Name</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">Iran's Oil and Nuclear Situation.doc</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                    </div>
+                                                                                                                                    <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                                 </div>
+                                                                                                                                 <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                    <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Size_In_Bytes</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">106604</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                    </div>
+                                                                                                                                    <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                                 </div>
+                                                                                                                                 <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                    <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Hashes</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                                                                          
+                                                                                                                                          </span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                    </div>
+                                                                                                                                    <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                                                                       <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                          <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Hash</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                                                                                
+                                                                                                                                                
+                                                                                                                                                </span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                          </div>
+                                                                                                                                          <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Type</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">MD5</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                                </div>
+                                                                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                                             </div>
+                                                                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Simple_Hash_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">E92A4FC283EB2802AD6D0E24C7FCC857</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                                </div>
+                                                                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                                             </div>
+                                                                                                                                          </div>
+                                                                                                                                       </div>
+                                                                                                                                    </div>
+                                                                                                                                 </div>
+                                                                                                                              </fieldset>
+                                                                                                                           </div>
+                                                                                                                        </div>
+                                                                                                                     </div>
+                                                                                                                  </div>
+                                                                                                               </div>
+                                                                                                            </div>
+                                                                                                            <div class="contents relatedObjectContents relatedObject">
+                                                                                                               <div></div>
+                                                                                                            </div>
+                                                                                                         </div>
+                                                                                                         <div class="container relatedObjectContainer relatedObject">
+                                                                                                            <div class="heading relatedObjectHeading relatedObject">
+                                                                                                               <div class="debug idStack">id stack: example:Observable-dee72b3e-82fb-4319-bfcc-007e3cf930e8,example:Object-bed1ff22-08e8-4e04-b7ac-908b5271176f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa</div>
+                                                                                                               <div class="expandableContainer expandableSeparate collapsed">
+                                                                                                                  <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Downloaded_From ○  URIObjectType ○ example:Object-61041b8b-0c15-48a0-ac5f-b49488788010 <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                                                  <div class="expandableContents">
+                                                                                                                     <div class="container associatedObjectContainer associatedObject">
+                                                                                                                        <div class="heading associatedObjectHeading associatedObject">
+                                                                                                                           <div class="debug idStack">id stack: example:Observable-dee72b3e-82fb-4319-bfcc-007e3cf930e8,example:Object-bed1ff22-08e8-4e04-b7ac-908b5271176f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa,example:Object-61041b8b-0c15-48a0-ac5f-b49488788010</div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents associatedObjectContents associatedObject">
+                                                                                                                           <div>
+                                                                                                                              <fieldset>
+                                                                                                                                 <legend>
+                                                                                                                                    cybox properties
+                                                                                                                                    (type: URIObjectType)
+                                                                                                                                    <span class="cyboxPropertiesSingleConstraint"> [type=URL]</span></legend>
+                                                                                                                                 <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                    <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">http://208.115.230.76/test.mp4</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                    </div>
+                                                                                                                                    <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                                 </div>
+                                                                                                                              </fieldset>
+                                                                                                                           </div>
+                                                                                                                        </div>
+                                                                                                                     </div>
+                                                                                                                  </div>
+                                                                                                               </div>
+                                                                                                            </div>
+                                                                                                            <div class="contents relatedObjectContents relatedObject">
+                                                                                                               <div></div>
+                                                                                                            </div>
+                                                                                                         </div>
+                                                                                                      </div>
+                                                                                                   </div>
+                                                                                                </div>
+                                                                                             </div>
+                                                                                          </div>
+                                                                                       </div>
+                                                                                    </div>
+                                                                                    <div class="contents relatedObjectContents relatedObject">
+                                                                                       <div></div>
+                                                                                    </div>
+                                                                                 </div>
+                                                                                 <div class="container relatedObjectContainer relatedObject">
+                                                                                    <div class="heading relatedObjectHeading relatedObject">
+                                                                                       <div class="debug idStack">id stack: example:Observable-dee72b3e-82fb-4319-bfcc-007e3cf930e8,example:Object-bed1ff22-08e8-4e04-b7ac-908b5271176f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c</div>
+                                                                                       <div class="expandableContainer expandableSeparate collapsed">
+                                                                                          <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Connected_To ○  URIObjectType ○ example:Object-41b220d8-4c45-48de-9d08-30d661b2dc8e <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                          <div class="expandableContents">
+                                                                                             <div class="container objectContainer object">
+                                                                                                <div class="heading objectHeading object">
+                                                                                                   <div class="debug idStack">id stack: example:Observable-dee72b3e-82fb-4319-bfcc-007e3cf930e8,example:Object-bed1ff22-08e8-4e04-b7ac-908b5271176f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-41b220d8-4c45-48de-9d08-30d661b2dc8e</div>
+                                                                                                </div>
+                                                                                                <div class="contents objectContents object">
+                                                                                                   <div>
+                                                                                                      <fieldset>
+                                                                                                         <legend>
+                                                                                                            cybox properties
+                                                                                                            (type: URIObjectType)
+                                                                                                            
+                                                                                                         </legend>
+                                                                                                         <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                            <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">www.documents.myPicture.info</span><div class="cyboxPropertiesLink"></div>
+                                                                                                            </div>
+                                                                                                            <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                         </div>
+                                                                                                      </fieldset>
+                                                                                                   </div>
+                                                                                                   <div class="container relatedObjects">
+                                                                                                      <div class="heading relatedObjects">Related Objects
+                                                                                                         
+                                                                                                      </div>
+                                                                                                      <div class="contents relatedObjects">
+                                                                                                         <div class="container relatedObjectContainer relatedObject">
+                                                                                                            <div class="heading relatedObjectHeading relatedObject">
+                                                                                                               <div class="debug idStack">id stack: example:Observable-dee72b3e-82fb-4319-bfcc-007e3cf930e8,example:Object-bed1ff22-08e8-4e04-b7ac-908b5271176f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-41b220d8-4c45-48de-9d08-30d661b2dc8e</div>
+                                                                                                               <div class="expandableContainer expandableSeparate collapsed">
+                                                                                                                  <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Resolved_To ○  AddressObjectType ○ example:Object-61aa225b-90ef-415c-8bbd-a17282e457c9 <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                                                  <div class="expandableContents">
+                                                                                                                     <div class="container objectContainer object">
+                                                                                                                        <div class="heading objectHeading object">
+                                                                                                                           <div class="debug idStack">id stack: example:Observable-dee72b3e-82fb-4319-bfcc-007e3cf930e8,example:Object-bed1ff22-08e8-4e04-b7ac-908b5271176f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-41b220d8-4c45-48de-9d08-30d661b2dc8e,example:Object-61aa225b-90ef-415c-8bbd-a17282e457c9</div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents objectContents object">
+                                                                                                                           <div>
+                                                                                                                              <fieldset>
+                                                                                                                                 <legend>
+                                                                                                                                    cybox properties
+                                                                                                                                    (type: AddressObjectType)
+                                                                                                                                    <span class="cyboxPropertiesSingleConstraint"> [category=ipv4-addr]</span></legend>
+                                                                                                                                 <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                    <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Address_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">199.192.156.134</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                    </div>
+                                                                                                                                    <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                                 </div>
+                                                                                                                              </fieldset>
+                                                                                                                           </div>
+                                                                                                                        </div>
+                                                                                                                     </div>
+                                                                                                                  </div>
+                                                                                                               </div>
+                                                                                                            </div>
+                                                                                                            <div class="contents relatedObjectContents relatedObject">
+                                                                                                               <div></div>
+                                                                                                            </div>
+                                                                                                         </div>
+                                                                                                      </div>
+                                                                                                   </div>
+                                                                                                </div>
+                                                                                             </div>
+                                                                                          </div>
+                                                                                       </div>
+                                                                                    </div>
+                                                                                    <div class="contents relatedObjectContents relatedObject">
+                                                                                       <div></div>
+                                                                                    </div>
+                                                                                 </div>
+                                                                                 <div class="container relatedObjectContainer relatedObject">
+                                                                                    <div class="heading relatedObjectHeading relatedObject">
+                                                                                       <div class="debug idStack">id stack: example:Observable-dee72b3e-82fb-4319-bfcc-007e3cf930e8,example:Object-bed1ff22-08e8-4e04-b7ac-908b5271176f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c</div>
+                                                                                       <div class="expandableContainer expandableSeparate collapsed">
+                                                                                          <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Connected_To ○  AddressObjectType ○ example:Object-61aa225b-90ef-415c-8bbd-a17282e457c9 <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                          <div class="expandableContents">
+                                                                                             <div class="container objectContainer object">
+                                                                                                <div class="heading objectHeading object">
+                                                                                                   <div class="debug idStack">id stack: example:Observable-dee72b3e-82fb-4319-bfcc-007e3cf930e8,example:Object-bed1ff22-08e8-4e04-b7ac-908b5271176f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-61aa225b-90ef-415c-8bbd-a17282e457c9</div>
+                                                                                                </div>
+                                                                                                <div class="contents objectContents object">
+                                                                                                   <div>
+                                                                                                      <fieldset>
+                                                                                                         <legend>
+                                                                                                            cybox properties
+                                                                                                            (type: AddressObjectType)
+                                                                                                            <span class="cyboxPropertiesSingleConstraint"> [category=ipv4-addr]</span></legend>
+                                                                                                         <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                            <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Address_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">199.192.156.134</span><div class="cyboxPropertiesLink"></div>
+                                                                                                            </div>
+                                                                                                            <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                         </div>
+                                                                                                      </fieldset>
+                                                                                                   </div>
+                                                                                                </div>
+                                                                                             </div>
+                                                                                          </div>
+                                                                                       </div>
+                                                                                    </div>
+                                                                                    <div class="contents relatedObjectContents relatedObject">
+                                                                                       <div></div>
+                                                                                    </div>
+                                                                                 </div>
+                                                                                 <div class="container relatedObjectContainer relatedObject">
+                                                                                    <div class="heading relatedObjectHeading relatedObject">
+                                                                                       <div class="debug idStack">id stack: example:Observable-dee72b3e-82fb-4319-bfcc-007e3cf930e8,example:Object-bed1ff22-08e8-4e04-b7ac-908b5271176f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c</div>
+                                                                                       <div class="expandableContainer expandableSeparate collapsed">
+                                                                                          <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Connected_To ○  URIObjectType ○ example:Object-568db11e-39ee-43d7-83d8-032bdec3801a <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                          <div class="expandableContents">
+                                                                                             <div class="container objectContainer object">
+                                                                                                <div class="heading objectHeading object">
+                                                                                                   <div class="debug idStack">id stack: example:Observable-dee72b3e-82fb-4319-bfcc-007e3cf930e8,example:Object-bed1ff22-08e8-4e04-b7ac-908b5271176f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-568db11e-39ee-43d7-83d8-032bdec3801a</div>
+                                                                                                </div>
+                                                                                                <div class="contents objectContents object">
+                                                                                                   <div>
+                                                                                                      <fieldset>
+                                                                                                         <legend>
+                                                                                                            cybox properties
+                                                                                                            (type: URIObjectType)
+                                                                                                            <span class="cyboxPropertiesSingleConstraint"> [type=URL]</span></legend>
+                                                                                                         <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                            <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">documents.myPicture.info</span><div class="cyboxPropertiesLink"></div>
+                                                                                                            </div>
+                                                                                                            <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                         </div>
+                                                                                                      </fieldset>
+                                                                                                   </div>
+                                                                                                   <div class="container relatedObjects">
+                                                                                                      <div class="heading relatedObjects">Related Objects
+                                                                                                         
+                                                                                                      </div>
+                                                                                                      <div class="contents relatedObjects">
+                                                                                                         <div class="container relatedObjectContainer relatedObject">
+                                                                                                            <div class="heading relatedObjectHeading relatedObject">
+                                                                                                               <div class="debug idStack">id stack: example:Observable-dee72b3e-82fb-4319-bfcc-007e3cf930e8,example:Object-bed1ff22-08e8-4e04-b7ac-908b5271176f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-568db11e-39ee-43d7-83d8-032bdec3801a</div>
+                                                                                                               <div class="expandableContainer expandableSeparate collapsed">
+                                                                                                                  <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Resolved_To ○  AddressObjectType ○ example:Object-80bea4d1-0e70-4a03-a54f-e40373bf94f1 <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                                                  <div class="expandableContents">
+                                                                                                                     <div class="container objectContainer object">
+                                                                                                                        <div class="heading objectHeading object">
+                                                                                                                           <div class="debug idStack">id stack: example:Observable-dee72b3e-82fb-4319-bfcc-007e3cf930e8,example:Object-bed1ff22-08e8-4e04-b7ac-908b5271176f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-568db11e-39ee-43d7-83d8-032bdec3801a,example:Object-80bea4d1-0e70-4a03-a54f-e40373bf94f1</div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents objectContents object">
+                                                                                                                           <div>
+                                                                                                                              <fieldset>
+                                                                                                                                 <legend>
+                                                                                                                                    cybox properties
+                                                                                                                                    (type: AddressObjectType)
+                                                                                                                                    <span class="cyboxPropertiesSingleConstraint"> [category=ipv4-addr]</span></legend>
+                                                                                                                                 <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                    <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Address_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">199.192.156.134</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                    </div>
+                                                                                                                                    <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                                 </div>
+                                                                                                                              </fieldset>
+                                                                                                                           </div>
+                                                                                                                        </div>
+                                                                                                                     </div>
+                                                                                                                  </div>
+                                                                                                               </div>
+                                                                                                            </div>
+                                                                                                            <div class="contents relatedObjectContents relatedObject">
+                                                                                                               <div></div>
+                                                                                                            </div>
+                                                                                                         </div>
+                                                                                                      </div>
+                                                                                                   </div>
+                                                                                                </div>
+                                                                                             </div>
+                                                                                          </div>
+                                                                                       </div>
+                                                                                    </div>
+                                                                                    <div class="contents relatedObjectContents relatedObject">
+                                                                                       <div></div>
+                                                                                    </div>
+                                                                                 </div>
+                                                                                 <div class="container relatedObjectContainer relatedObject">
+                                                                                    <div class="heading relatedObjectHeading relatedObject">
+                                                                                       <div class="debug idStack">id stack: example:Observable-dee72b3e-82fb-4319-bfcc-007e3cf930e8,example:Object-bed1ff22-08e8-4e04-b7ac-908b5271176f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c</div>
+                                                                                       <div class="expandableContainer expandableSeparate collapsed">
+                                                                                          <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Connected_To ○  AddressObjectType ○ example:Object-80bea4d1-0e70-4a03-a54f-e40373bf94f1 <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                          <div class="expandableContents">
+                                                                                             <div class="container objectContainer object">
+                                                                                                <div class="heading objectHeading object">
+                                                                                                   <div class="debug idStack">id stack: example:Observable-dee72b3e-82fb-4319-bfcc-007e3cf930e8,example:Object-bed1ff22-08e8-4e04-b7ac-908b5271176f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-80bea4d1-0e70-4a03-a54f-e40373bf94f1</div>
+                                                                                                </div>
+                                                                                                <div class="contents objectContents object">
+                                                                                                   <div>
+                                                                                                      <fieldset>
+                                                                                                         <legend>
+                                                                                                            cybox properties
+                                                                                                            (type: AddressObjectType)
+                                                                                                            <span class="cyboxPropertiesSingleConstraint"> [category=ipv4-addr]</span></legend>
+                                                                                                         <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                            <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Address_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">199.192.156.134</span><div class="cyboxPropertiesLink"></div>
+                                                                                                            </div>
+                                                                                                            <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                         </div>
+                                                                                                      </fieldset>
+                                                                                                   </div>
+                                                                                                </div>
+                                                                                             </div>
+                                                                                          </div>
+                                                                                       </div>
+                                                                                    </div>
+                                                                                    <div class="contents relatedObjectContents relatedObject">
+                                                                                       <div></div>
+                                                                                    </div>
+                                                                                 </div>
+                                                                                 <div class="container relatedObjectContainer relatedObject">
+                                                                                    <div class="heading relatedObjectHeading relatedObject">
+                                                                                       <div class="debug idStack">id stack: example:Observable-dee72b3e-82fb-4319-bfcc-007e3cf930e8,example:Object-bed1ff22-08e8-4e04-b7ac-908b5271176f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c</div>
+                                                                                       <div class="expandableContainer expandableSeparate collapsed">
+                                                                                          <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Connected_To ○  URIObjectType ○ example:Object-af7cb3b6-d70b-4b3b-b24f-7cfad739710f <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                          <div class="expandableContents">
+                                                                                             <div class="container objectContainer object">
+                                                                                                <div class="heading objectHeading object">
+                                                                                                   <div class="debug idStack">id stack: example:Observable-dee72b3e-82fb-4319-bfcc-007e3cf930e8,example:Object-bed1ff22-08e8-4e04-b7ac-908b5271176f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-af7cb3b6-d70b-4b3b-b24f-7cfad739710f</div>
+                                                                                                </div>
+                                                                                                <div class="contents objectContents object">
+                                                                                                   <div>
+                                                                                                      <fieldset>
+                                                                                                         <legend>
+                                                                                                            cybox properties
+                                                                                                            (type: URIObjectType)
+                                                                                                            <span class="cyboxPropertiesSingleConstraint"> [type=URL]</span></legend>
+                                                                                                         <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                            <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">ftp.documents.myPicture.info</span><div class="cyboxPropertiesLink"></div>
+                                                                                                            </div>
+                                                                                                            <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                         </div>
+                                                                                                      </fieldset>
+                                                                                                   </div>
+                                                                                                   <div class="container relatedObjects">
+                                                                                                      <div class="heading relatedObjects">Related Objects
+                                                                                                         
+                                                                                                      </div>
+                                                                                                      <div class="contents relatedObjects">
+                                                                                                         <div class="container relatedObjectContainer relatedObject">
+                                                                                                            <div class="heading relatedObjectHeading relatedObject">
+                                                                                                               <div class="debug idStack">id stack: example:Observable-dee72b3e-82fb-4319-bfcc-007e3cf930e8,example:Object-bed1ff22-08e8-4e04-b7ac-908b5271176f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-af7cb3b6-d70b-4b3b-b24f-7cfad739710f</div>
+                                                                                                               <div class="expandableContainer expandableSeparate collapsed">
+                                                                                                                  <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Resolved_To ○  AddressObjectType ○ example:Object-5ceb9d54-24e2-4627-948d-6b92ac81962a <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                                                  <div class="expandableContents">
+                                                                                                                     <div class="container objectContainer object">
+                                                                                                                        <div class="heading objectHeading object">
+                                                                                                                           <div class="debug idStack">id stack: example:Observable-dee72b3e-82fb-4319-bfcc-007e3cf930e8,example:Object-bed1ff22-08e8-4e04-b7ac-908b5271176f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-af7cb3b6-d70b-4b3b-b24f-7cfad739710f,example:Object-5ceb9d54-24e2-4627-948d-6b92ac81962a</div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents objectContents object">
+                                                                                                                           <div>
+                                                                                                                              <fieldset>
+                                                                                                                                 <legend>
+                                                                                                                                    cybox properties
+                                                                                                                                    (type: AddressObjectType)
+                                                                                                                                    <span class="cyboxPropertiesSingleConstraint"> [category=ipv4-addr]</span></legend>
+                                                                                                                                 <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                    <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Address_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">199.192.156.134</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                    </div>
+                                                                                                                                    <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                                 </div>
+                                                                                                                              </fieldset>
+                                                                                                                           </div>
+                                                                                                                        </div>
+                                                                                                                     </div>
+                                                                                                                  </div>
+                                                                                                               </div>
+                                                                                                            </div>
+                                                                                                            <div class="contents relatedObjectContents relatedObject">
+                                                                                                               <div></div>
+                                                                                                            </div>
+                                                                                                         </div>
+                                                                                                      </div>
+                                                                                                   </div>
+                                                                                                </div>
+                                                                                             </div>
+                                                                                          </div>
+                                                                                       </div>
+                                                                                    </div>
+                                                                                    <div class="contents relatedObjectContents relatedObject">
+                                                                                       <div></div>
+                                                                                    </div>
+                                                                                 </div>
+                                                                                 <div class="container relatedObjectContainer relatedObject">
+                                                                                    <div class="heading relatedObjectHeading relatedObject">
+                                                                                       <div class="debug idStack">id stack: example:Observable-dee72b3e-82fb-4319-bfcc-007e3cf930e8,example:Object-bed1ff22-08e8-4e04-b7ac-908b5271176f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c</div>
+                                                                                       <div class="objectReference nonexpandableContainer"> <span class="externalLinkWarning">[external]</span>  ○ example:guid-5ceb9d54-24e2-4627-948d-6b92ac81962a <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                    </div>
+                                                                                    <div class="contents relatedObjectContents relatedObject">
+                                                                                       <div></div>
+                                                                                    </div>
+                                                                                 </div>
+                                                                              </div>
+                                                                           </div>
+                                                                        </div>
+                                                                     </div>
+                                                                  </div>
+                                                               </div>
+                                                            </div>
+                                                            <div class="contents relatedObjectContents relatedObject">
+                                                               <div></div>
+                                                            </div>
+                                                         </div>
+                                                      </div>
+                                                   </div>
+                                                </div>
+                                             </div>
+                                          </td>
+                                       </tr>
+                                    </tbody>
+                                 </table>
+                              </div>
+                           </div>
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR style="width:100%;font-style:italic;">
+                     <TD colspan="2">
+                        <div style="font-size:13px; font-style: italic; display:none;" id="7_ind_description">Test Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!! Test
+                           Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre
+                           Artifact Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre Artifact
+                           Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!!
+                           Test Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!! Test
+                           Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre
+                           Artifact Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre Artifact
+                           Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!!
+                           Test Malwawre Artifact Information!!!! 
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR class="">
+                     <TD>
+                        <div id="fileObjAtt" class="collapsibleLabel" style="cursor: pointer;" onclick="toggleDiv('700000000474','d1e483','d1e483-2')"><span id="d1e483" style="font-weight:bold; margin:5px; color:#BD9C8C;">+</span>example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f
+                        </div>
+                     </TD>
+                     <TD>
+                        <div style="cursor: pointer;" onclick="toggleDiv('700000000474','d1e483','d1e483-2')"><span id="d1e483-2" style="font-weight:bold; margin:5px; color:#BD9C8C;">+</span>
+                           Event
+                           
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR class="">
+                     <TD colspan="2">
+                        <div id="700000000474" class="collapsibleContent" style="overflow:hidden; display:none; padding:0px 7px;">
+                           <div id="example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f">
+                              <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f</div><br><div id="section">
+                                 <table class="one-column-emphasis">
+                                    <colgroup>
+                                       <col class="oce-first-obs">
+                                    </colgroup>
+                                    <tbody>
+                                       <tr>
+                                          <td>
+                                             <div class="container eventContainer event">
+                                                <div class="heading eventHeading event">
+                                                   <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f</div>
+                                                </div>
+                                                <div class="contents eventContents event">
+                                                   <div class="eventDescription description">
+                                                      description: Trojan .exe file connects out to C2 URLs/IPs.
+                                                   </div>
+                                                   <div class="container">
+                                                      <div class="heading actions">Actions</div>
+                                                      <div class="contents actions">
+                                                         <div class="container action">
+                                                            <div class="heading action">ACTION Connect (xsi type: cyboxVocabs:ActionTypeVocab-1.0)</div>
+                                                            <div class="contents action">
+                                                               <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f</div>
+                                                               <div class="container associatedObjects">
+                                                                  <div class="heading associatedObjects">Associated Objects
+                                                                     
+                                                                  </div>
+                                                                  <div class="contents associatedObjects">
+                                                                     <div class="container associatedObjectContainer associatedObject">
+                                                                        <div class="heading associatedObjectHeading associatedObject">
+                                                                           <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f</div>
+                                                                           <div class="expandableContainer expandableSeparate collapsed">
+                                                                              <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Initiating ○  FileObjectType ○ example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                              <div class="expandableContents">
+                                                                                 <div class="container associatedObjectContainer associatedObject">
+                                                                                    <div class="heading associatedObjectHeading associatedObject">
+                                                                                       <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c</div>
+                                                                                    </div>
+                                                                                    <div class="contents associatedObjectContents associatedObject">
+                                                                                       <div class="associatedObjectDescription description">
+                                                                                          description: 
+                                                                                          The file (us.exe MD5: FD1BE09E499E8E380424B3835FC973A8
+                                                                                          4861440 bytes) is created in the logged in user %Temp%
+                                                                                          directory. The size of the embedded file is 22.5 KB (23040
+                                                                                          bytes) and the size of the created us.exe is 4.63MB. It is an
+                                                                                          odd discrepancy until you look at the file and it looks like the
+                                                                                          code is repeated over and over - 211 times. The file resource
+                                                                                          section indicates the file is meant to look like a java updater,
+                                                                                          which is always larger than 22.5KB and that would explain all
+                                                                                          this padding, which is done at the time when the file is being
+                                                                                          written to the disk.
+                                                                                          
+                                                                                       </div>
+                                                                                       <div>
+                                                                                          <fieldset>
+                                                                                             <legend>
+                                                                                                cybox properties
+                                                                                                (type: FileObjectType)
+                                                                                                
+                                                                                             </legend>
+                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">File_Name</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">us.exe</span><div class="cyboxPropertiesLink"></div>
+                                                                                                </div>
+                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                             </div>
+                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">File_Path</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">%Temp%</span><div class="cyboxPropertiesLink"></div>
+                                                                                                </div>
+                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                             </div>
+                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Size_In_Bytes</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">4861440</span><div class="cyboxPropertiesLink"></div>
+                                                                                                </div>
+                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                             </div>
+                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Hashes</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                                      
+                                                                                                      </span><div class="cyboxPropertiesLink"></div>
+                                                                                                </div>
+                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                                   <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                      <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Hash</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                                            
+                                                                                                            
+                                                                                                            </span><div class="cyboxPropertiesLink"></div>
+                                                                                                      </div>
+                                                                                                      <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                                         <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                            <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Type</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">MD5</span><div class="cyboxPropertiesLink"></div>
+                                                                                                            </div>
+                                                                                                            <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                         </div>
+                                                                                                         <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                            <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Simple_Hash_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">FD1BE09E499E8E380424B3835FC973A8</span><div class="cyboxPropertiesLink"></div>
+                                                                                                            </div>
+                                                                                                            <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                         </div>
+                                                                                                      </div>
+                                                                                                   </div>
+                                                                                                </div>
+                                                                                             </div>
+                                                                                          </fieldset>
+                                                                                       </div>
+                                                                                       <div class="container relatedObjects">
+                                                                                          <div class="heading relatedObjects">Related Objects
+                                                                                             
+                                                                                          </div>
+                                                                                          <div class="contents relatedObjects">
+                                                                                             <div class="container relatedObjectContainer relatedObject">
+                                                                                                <div class="heading relatedObjectHeading relatedObject">
+                                                                                                   <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c</div>
+                                                                                                   <div class="expandableContainer expandableSeparate collapsed">
+                                                                                                      <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Created_By ○  FileObjectType ○ example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                                      <div class="expandableContents">
+                                                                                                         <div class="container associatedObjectContainer associatedObject">
+                                                                                                            <div class="heading associatedObjectHeading associatedObject">
+                                                                                                               <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa</div>
+                                                                                                            </div>
+                                                                                                            <div class="contents associatedObjectContents associatedObject">
+                                                                                                               <div class="associatedObjectDescription description">
+                                                                                                                  description: 
+                                                                                                                  This mp4 file causes memory corruption and code
+                                                                                                                  execution via heap-spraying code injection.
+                                                                                                                  
+                                                                                                               </div>
+                                                                                                               <div>
+                                                                                                                  <fieldset>
+                                                                                                                     <legend>
+                                                                                                                        cybox properties
+                                                                                                                        (type: FileObjectType)
+                                                                                                                        
+                                                                                                                     </legend>
+                                                                                                                     <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                        <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">File_Name</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">test.mp4</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                     </div>
+                                                                                                                     <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                        <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Size_In_Bytes</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">22384</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                     </div>
+                                                                                                                     <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                        <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Hashes</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                                                              
+                                                                                                                              </span><div class="cyboxPropertiesLink"></div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                                                           <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                              <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Hash</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                                                                    
+                                                                                                                                    
+                                                                                                                                    </span><div class="cyboxPropertiesLink"></div>
+                                                                                                                              </div>
+                                                                                                                              <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                                                                 <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                    <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Type</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">MD5</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                    </div>
+                                                                                                                                    <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                                 </div>
+                                                                                                                                 <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                    <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Simple_Hash_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">8933598C8B1FA5E493497B11C48DA4F2</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                    </div>
+                                                                                                                                    <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                                 </div>
+                                                                                                                              </div>
+                                                                                                                           </div>
+                                                                                                                        </div>
+                                                                                                                     </div>
+                                                                                                                  </fieldset>
+                                                                                                               </div>
+                                                                                                               <div class="container relatedObjects">
+                                                                                                                  <div class="heading relatedObjects">Related Objects
+                                                                                                                     
+                                                                                                                  </div>
+                                                                                                                  <div class="contents relatedObjects">
+                                                                                                                     <div class="container relatedObjectContainer relatedObject">
+                                                                                                                        <div class="heading relatedObjectHeading relatedObject">
+                                                                                                                           <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa</div>
+                                                                                                                           <div class="expandableContainer expandableSeparate collapsed">
+                                                                                                                              <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Downloaded_By ○  FileObjectType ○ example:Object-49d31c13-8d7b-4528-b8d6-ce8ed0d43ad7 <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                                                              <div class="expandableContents">
+                                                                                                                                 <div class="container associatedObjectContainer associatedObject">
+                                                                                                                                    <div class="heading associatedObjectHeading associatedObject">
+                                                                                                                                       <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa,example:Object-49d31c13-8d7b-4528-b8d6-ce8ed0d43ad7</div>
+                                                                                                                                    </div>
+                                                                                                                                    <div class="contents associatedObjectContents associatedObject">
+                                                                                                                                       <div class="associatedObjectDescription description">
+                                                                                                                                          description: 
+                                                                                                                                          The word document contains flash, which downloads a
+                                                                                                                                          corrupted mp4 file. The mp4 file itself is not anything special
+                                                                                                                                          but an 0C filled (22kb) mp4 file with a valid mp4
+                                                                                                                                          header.
+                                                                                                                                          
+                                                                                                                                       </div>
+                                                                                                                                       <div>
+                                                                                                                                          <fieldset>
+                                                                                                                                             <legend>
+                                                                                                                                                cybox properties
+                                                                                                                                                (type: FileObjectType)
+                                                                                                                                                
+                                                                                                                                             </legend>
+                                                                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">File_Name</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">Iran's Oil and Nuclear Situation.doc</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                                </div>
+                                                                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                                             </div>
+                                                                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Size_In_Bytes</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">106604</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                                </div>
+                                                                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                                             </div>
+                                                                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Hashes</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                                                                                      
+                                                                                                                                                      </span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                                </div>
+                                                                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                                                                                   <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                                      <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Hash</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">
+                                                                                                                                                            
+                                                                                                                                                            
+                                                                                                                                                            </span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                                      </div>
+                                                                                                                                                      <div class="contents cyboxPropertiesContents cyboxProperties">
+                                                                                                                                                         <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                                            <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Type</span><span class="cyboxPropertiesConstraints"></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">MD5</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                                            </div>
+                                                                                                                                                            <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                                                         </div>
+                                                                                                                                                         <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                                            <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Simple_Hash_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">E92A4FC283EB2802AD6D0E24C7FCC857</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                                            </div>
+                                                                                                                                                            <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                                                         </div>
+                                                                                                                                                      </div>
+                                                                                                                                                   </div>
+                                                                                                                                                </div>
+                                                                                                                                             </div>
+                                                                                                                                          </fieldset>
+                                                                                                                                       </div>
+                                                                                                                                    </div>
+                                                                                                                                 </div>
+                                                                                                                              </div>
+                                                                                                                           </div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents relatedObjectContents relatedObject">
+                                                                                                                           <div></div>
+                                                                                                                        </div>
+                                                                                                                     </div>
+                                                                                                                     <div class="container relatedObjectContainer relatedObject">
+                                                                                                                        <div class="heading relatedObjectHeading relatedObject">
+                                                                                                                           <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa</div>
+                                                                                                                           <div class="expandableContainer expandableSeparate collapsed">
+                                                                                                                              <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Downloaded_From ○  URIObjectType ○ example:Object-61041b8b-0c15-48a0-ac5f-b49488788010 <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                                                              <div class="expandableContents">
+                                                                                                                                 <div class="container associatedObjectContainer associatedObject">
+                                                                                                                                    <div class="heading associatedObjectHeading associatedObject">
+                                                                                                                                       <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa,example:Object-61041b8b-0c15-48a0-ac5f-b49488788010</div>
+                                                                                                                                    </div>
+                                                                                                                                    <div class="contents associatedObjectContents associatedObject">
+                                                                                                                                       <div>
+                                                                                                                                          <fieldset>
+                                                                                                                                             <legend>
+                                                                                                                                                cybox properties
+                                                                                                                                                (type: URIObjectType)
+                                                                                                                                                <span class="cyboxPropertiesSingleConstraint"> [type=URL]</span></legend>
+                                                                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">http://208.115.230.76/test.mp4</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                                </div>
+                                                                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                                             </div>
+                                                                                                                                          </fieldset>
+                                                                                                                                       </div>
+                                                                                                                                    </div>
+                                                                                                                                 </div>
+                                                                                                                              </div>
+                                                                                                                           </div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents relatedObjectContents relatedObject">
+                                                                                                                           <div></div>
+                                                                                                                        </div>
+                                                                                                                     </div>
+                                                                                                                  </div>
+                                                                                                               </div>
+                                                                                                            </div>
+                                                                                                         </div>
+                                                                                                      </div>
+                                                                                                   </div>
+                                                                                                </div>
+                                                                                                <div class="contents relatedObjectContents relatedObject">
+                                                                                                   <div></div>
+                                                                                                </div>
+                                                                                             </div>
+                                                                                             <div class="container relatedObjectContainer relatedObject">
+                                                                                                <div class="heading relatedObjectHeading relatedObject">
+                                                                                                   <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c</div>
+                                                                                                   <div class="expandableContainer expandableSeparate collapsed">
+                                                                                                      <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Connected_To ○  URIObjectType ○ example:Object-41b220d8-4c45-48de-9d08-30d661b2dc8e <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                                      <div class="expandableContents">
+                                                                                                         <div class="container objectContainer object">
+                                                                                                            <div class="heading objectHeading object">
+                                                                                                               <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-41b220d8-4c45-48de-9d08-30d661b2dc8e</div>
+                                                                                                            </div>
+                                                                                                            <div class="contents objectContents object">
+                                                                                                               <div>
+                                                                                                                  <fieldset>
+                                                                                                                     <legend>
+                                                                                                                        cybox properties
+                                                                                                                        (type: URIObjectType)
+                                                                                                                        
+                                                                                                                     </legend>
+                                                                                                                     <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                        <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">www.documents.myPicture.info</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                     </div>
+                                                                                                                  </fieldset>
+                                                                                                               </div>
+                                                                                                               <div class="container relatedObjects">
+                                                                                                                  <div class="heading relatedObjects">Related Objects
+                                                                                                                     
+                                                                                                                  </div>
+                                                                                                                  <div class="contents relatedObjects">
+                                                                                                                     <div class="container relatedObjectContainer relatedObject">
+                                                                                                                        <div class="heading relatedObjectHeading relatedObject">
+                                                                                                                           <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-41b220d8-4c45-48de-9d08-30d661b2dc8e</div>
+                                                                                                                           <div class="expandableContainer expandableSeparate collapsed">
+                                                                                                                              <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Resolved_To ○  AddressObjectType ○ example:Object-61aa225b-90ef-415c-8bbd-a17282e457c9 <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                                                              <div class="expandableContents">
+                                                                                                                                 <div class="container objectContainer object">
+                                                                                                                                    <div class="heading objectHeading object">
+                                                                                                                                       <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-41b220d8-4c45-48de-9d08-30d661b2dc8e,example:Object-61aa225b-90ef-415c-8bbd-a17282e457c9</div>
+                                                                                                                                    </div>
+                                                                                                                                    <div class="contents objectContents object">
+                                                                                                                                       <div>
+                                                                                                                                          <fieldset>
+                                                                                                                                             <legend>
+                                                                                                                                                cybox properties
+                                                                                                                                                (type: AddressObjectType)
+                                                                                                                                                <span class="cyboxPropertiesSingleConstraint"> [category=ipv4-addr]</span></legend>
+                                                                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Address_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">199.192.156.134</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                                </div>
+                                                                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                                             </div>
+                                                                                                                                          </fieldset>
+                                                                                                                                       </div>
+                                                                                                                                    </div>
+                                                                                                                                 </div>
+                                                                                                                              </div>
+                                                                                                                           </div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents relatedObjectContents relatedObject">
+                                                                                                                           <div></div>
+                                                                                                                        </div>
+                                                                                                                     </div>
+                                                                                                                  </div>
+                                                                                                               </div>
+                                                                                                            </div>
+                                                                                                         </div>
+                                                                                                      </div>
+                                                                                                   </div>
+                                                                                                </div>
+                                                                                                <div class="contents relatedObjectContents relatedObject">
+                                                                                                   <div></div>
+                                                                                                </div>
+                                                                                             </div>
+                                                                                             <div class="container relatedObjectContainer relatedObject">
+                                                                                                <div class="heading relatedObjectHeading relatedObject">
+                                                                                                   <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c</div>
+                                                                                                   <div class="expandableContainer expandableSeparate collapsed">
+                                                                                                      <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Connected_To ○  AddressObjectType ○ example:Object-61aa225b-90ef-415c-8bbd-a17282e457c9 <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                                      <div class="expandableContents">
+                                                                                                         <div class="container objectContainer object">
+                                                                                                            <div class="heading objectHeading object">
+                                                                                                               <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-61aa225b-90ef-415c-8bbd-a17282e457c9</div>
+                                                                                                            </div>
+                                                                                                            <div class="contents objectContents object">
+                                                                                                               <div>
+                                                                                                                  <fieldset>
+                                                                                                                     <legend>
+                                                                                                                        cybox properties
+                                                                                                                        (type: AddressObjectType)
+                                                                                                                        <span class="cyboxPropertiesSingleConstraint"> [category=ipv4-addr]</span></legend>
+                                                                                                                     <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                        <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Address_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">199.192.156.134</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                     </div>
+                                                                                                                  </fieldset>
+                                                                                                               </div>
+                                                                                                            </div>
+                                                                                                         </div>
+                                                                                                      </div>
+                                                                                                   </div>
+                                                                                                </div>
+                                                                                                <div class="contents relatedObjectContents relatedObject">
+                                                                                                   <div></div>
+                                                                                                </div>
+                                                                                             </div>
+                                                                                             <div class="container relatedObjectContainer relatedObject">
+                                                                                                <div class="heading relatedObjectHeading relatedObject">
+                                                                                                   <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c</div>
+                                                                                                   <div class="expandableContainer expandableSeparate collapsed">
+                                                                                                      <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Connected_To ○  URIObjectType ○ example:Object-568db11e-39ee-43d7-83d8-032bdec3801a <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                                      <div class="expandableContents">
+                                                                                                         <div class="container objectContainer object">
+                                                                                                            <div class="heading objectHeading object">
+                                                                                                               <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-568db11e-39ee-43d7-83d8-032bdec3801a</div>
+                                                                                                            </div>
+                                                                                                            <div class="contents objectContents object">
+                                                                                                               <div>
+                                                                                                                  <fieldset>
+                                                                                                                     <legend>
+                                                                                                                        cybox properties
+                                                                                                                        (type: URIObjectType)
+                                                                                                                        <span class="cyboxPropertiesSingleConstraint"> [type=URL]</span></legend>
+                                                                                                                     <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                        <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">documents.myPicture.info</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                     </div>
+                                                                                                                  </fieldset>
+                                                                                                               </div>
+                                                                                                               <div class="container relatedObjects">
+                                                                                                                  <div class="heading relatedObjects">Related Objects
+                                                                                                                     
+                                                                                                                  </div>
+                                                                                                                  <div class="contents relatedObjects">
+                                                                                                                     <div class="container relatedObjectContainer relatedObject">
+                                                                                                                        <div class="heading relatedObjectHeading relatedObject">
+                                                                                                                           <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-568db11e-39ee-43d7-83d8-032bdec3801a</div>
+                                                                                                                           <div class="expandableContainer expandableSeparate collapsed">
+                                                                                                                              <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Resolved_To ○  AddressObjectType ○ example:Object-80bea4d1-0e70-4a03-a54f-e40373bf94f1 <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                                                              <div class="expandableContents">
+                                                                                                                                 <div class="container objectContainer object">
+                                                                                                                                    <div class="heading objectHeading object">
+                                                                                                                                       <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-568db11e-39ee-43d7-83d8-032bdec3801a,example:Object-80bea4d1-0e70-4a03-a54f-e40373bf94f1</div>
+                                                                                                                                    </div>
+                                                                                                                                    <div class="contents objectContents object">
+                                                                                                                                       <div>
+                                                                                                                                          <fieldset>
+                                                                                                                                             <legend>
+                                                                                                                                                cybox properties
+                                                                                                                                                (type: AddressObjectType)
+                                                                                                                                                <span class="cyboxPropertiesSingleConstraint"> [category=ipv4-addr]</span></legend>
+                                                                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Address_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">199.192.156.134</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                                </div>
+                                                                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                                             </div>
+                                                                                                                                          </fieldset>
+                                                                                                                                       </div>
+                                                                                                                                    </div>
+                                                                                                                                 </div>
+                                                                                                                              </div>
+                                                                                                                           </div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents relatedObjectContents relatedObject">
+                                                                                                                           <div></div>
+                                                                                                                        </div>
+                                                                                                                     </div>
+                                                                                                                  </div>
+                                                                                                               </div>
+                                                                                                            </div>
+                                                                                                         </div>
+                                                                                                      </div>
+                                                                                                   </div>
+                                                                                                </div>
+                                                                                                <div class="contents relatedObjectContents relatedObject">
+                                                                                                   <div></div>
+                                                                                                </div>
+                                                                                             </div>
+                                                                                             <div class="container relatedObjectContainer relatedObject">
+                                                                                                <div class="heading relatedObjectHeading relatedObject">
+                                                                                                   <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c</div>
+                                                                                                   <div class="expandableContainer expandableSeparate collapsed">
+                                                                                                      <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Connected_To ○  AddressObjectType ○ example:Object-80bea4d1-0e70-4a03-a54f-e40373bf94f1 <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                                      <div class="expandableContents">
+                                                                                                         <div class="container objectContainer object">
+                                                                                                            <div class="heading objectHeading object">
+                                                                                                               <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-80bea4d1-0e70-4a03-a54f-e40373bf94f1</div>
+                                                                                                            </div>
+                                                                                                            <div class="contents objectContents object">
+                                                                                                               <div>
+                                                                                                                  <fieldset>
+                                                                                                                     <legend>
+                                                                                                                        cybox properties
+                                                                                                                        (type: AddressObjectType)
+                                                                                                                        <span class="cyboxPropertiesSingleConstraint"> [category=ipv4-addr]</span></legend>
+                                                                                                                     <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                        <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Address_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">199.192.156.134</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                     </div>
+                                                                                                                  </fieldset>
+                                                                                                               </div>
+                                                                                                            </div>
+                                                                                                         </div>
+                                                                                                      </div>
+                                                                                                   </div>
+                                                                                                </div>
+                                                                                                <div class="contents relatedObjectContents relatedObject">
+                                                                                                   <div></div>
+                                                                                                </div>
+                                                                                             </div>
+                                                                                             <div class="container relatedObjectContainer relatedObject">
+                                                                                                <div class="heading relatedObjectHeading relatedObject">
+                                                                                                   <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c</div>
+                                                                                                   <div class="expandableContainer expandableSeparate collapsed">
+                                                                                                      <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Connected_To ○  URIObjectType ○ example:Object-af7cb3b6-d70b-4b3b-b24f-7cfad739710f <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                                      <div class="expandableContents">
+                                                                                                         <div class="container objectContainer object">
+                                                                                                            <div class="heading objectHeading object">
+                                                                                                               <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-af7cb3b6-d70b-4b3b-b24f-7cfad739710f</div>
+                                                                                                            </div>
+                                                                                                            <div class="contents objectContents object">
+                                                                                                               <div>
+                                                                                                                  <fieldset>
+                                                                                                                     <legend>
+                                                                                                                        cybox properties
+                                                                                                                        (type: URIObjectType)
+                                                                                                                        <span class="cyboxPropertiesSingleConstraint"> [type=URL]</span></legend>
+                                                                                                                     <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                        <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">ftp.documents.myPicture.info</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                     </div>
+                                                                                                                  </fieldset>
+                                                                                                               </div>
+                                                                                                               <div class="container relatedObjects">
+                                                                                                                  <div class="heading relatedObjects">Related Objects
+                                                                                                                     
+                                                                                                                  </div>
+                                                                                                                  <div class="contents relatedObjects">
+                                                                                                                     <div class="container relatedObjectContainer relatedObject">
+                                                                                                                        <div class="heading relatedObjectHeading relatedObject">
+                                                                                                                           <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-af7cb3b6-d70b-4b3b-b24f-7cfad739710f</div>
+                                                                                                                           <div class="expandableContainer expandableSeparate collapsed">
+                                                                                                                              <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Resolved_To ○  AddressObjectType ○ example:Object-5ceb9d54-24e2-4627-948d-6b92ac81962a <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                                                              <div class="expandableContents">
+                                                                                                                                 <div class="container objectContainer object">
+                                                                                                                                    <div class="heading objectHeading object">
+                                                                                                                                       <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c,example:Object-af7cb3b6-d70b-4b3b-b24f-7cfad739710f,example:Object-5ceb9d54-24e2-4627-948d-6b92ac81962a</div>
+                                                                                                                                    </div>
+                                                                                                                                    <div class="contents objectContents object">
+                                                                                                                                       <div>
+                                                                                                                                          <fieldset>
+                                                                                                                                             <legend>
+                                                                                                                                                cybox properties
+                                                                                                                                                (type: AddressObjectType)
+                                                                                                                                                <span class="cyboxPropertiesSingleConstraint"> [category=ipv4-addr]</span></legend>
+                                                                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Address_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">199.192.156.134</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                                                </div>
+                                                                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                                             </div>
+                                                                                                                                          </fieldset>
+                                                                                                                                       </div>
+                                                                                                                                    </div>
+                                                                                                                                 </div>
+                                                                                                                              </div>
+                                                                                                                           </div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents relatedObjectContents relatedObject">
+                                                                                                                           <div></div>
+                                                                                                                        </div>
+                                                                                                                     </div>
+                                                                                                                  </div>
+                                                                                                               </div>
+                                                                                                            </div>
+                                                                                                         </div>
+                                                                                                      </div>
+                                                                                                   </div>
+                                                                                                </div>
+                                                                                                <div class="contents relatedObjectContents relatedObject">
+                                                                                                   <div></div>
+                                                                                                </div>
+                                                                                             </div>
+                                                                                             <div class="container relatedObjectContainer relatedObject">
+                                                                                                <div class="heading relatedObjectHeading relatedObject">
+                                                                                                   <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f,example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c</div>
+                                                                                                   <div class="objectReference nonexpandableContainer"> <span class="externalLinkWarning">[external]</span>  ○ example:guid-5ceb9d54-24e2-4627-948d-6b92ac81962a <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                                </div>
+                                                                                                <div class="contents relatedObjectContents relatedObject">
+                                                                                                   <div></div>
+                                                                                                </div>
+                                                                                             </div>
+                                                                                          </div>
+                                                                                       </div>
+                                                                                    </div>
+                                                                                 </div>
+                                                                              </div>
+                                                                           </div>
+                                                                        </div>
+                                                                        <div class="contents associatedObjectContents associatedObject">
+                                                                           <div></div>
+                                                                        </div>
+                                                                     </div>
+                                                                     <div class="container associatedObjectContainer associatedObject">
+                                                                        <div class="heading associatedObjectHeading associatedObject">
+                                                                           <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f</div>
+                                                                           <div class="expandableContainer expandableSeparate collapsed">
+                                                                              <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Utilized ○  URIObjectType ○ example:Object-41b220d8-4c45-48de-9d08-30d661b2dc8e <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                              <div class="expandableContents">
+                                                                                 <div class="container objectContainer object">
+                                                                                    <div class="heading objectHeading object">
+                                                                                       <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f,example:Object-41b220d8-4c45-48de-9d08-30d661b2dc8e</div>
+                                                                                    </div>
+                                                                                    <div class="contents objectContents object">
+                                                                                       <div>
+                                                                                          <fieldset>
+                                                                                             <legend>
+                                                                                                cybox properties
+                                                                                                (type: URIObjectType)
+                                                                                                
+                                                                                             </legend>
+                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">www.documents.myPicture.info</span><div class="cyboxPropertiesLink"></div>
+                                                                                                </div>
+                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                             </div>
+                                                                                          </fieldset>
+                                                                                       </div>
+                                                                                       <div class="container relatedObjects">
+                                                                                          <div class="heading relatedObjects">Related Objects
+                                                                                             
+                                                                                          </div>
+                                                                                          <div class="contents relatedObjects">
+                                                                                             <div class="container relatedObjectContainer relatedObject">
+                                                                                                <div class="heading relatedObjectHeading relatedObject">
+                                                                                                   <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f,example:Object-41b220d8-4c45-48de-9d08-30d661b2dc8e</div>
+                                                                                                   <div class="expandableContainer expandableSeparate collapsed">
+                                                                                                      <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Resolved_To ○  AddressObjectType ○ example:Object-61aa225b-90ef-415c-8bbd-a17282e457c9 <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                                      <div class="expandableContents">
+                                                                                                         <div class="container objectContainer object">
+                                                                                                            <div class="heading objectHeading object">
+                                                                                                               <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f,example:Object-41b220d8-4c45-48de-9d08-30d661b2dc8e,example:Object-61aa225b-90ef-415c-8bbd-a17282e457c9</div>
+                                                                                                            </div>
+                                                                                                            <div class="contents objectContents object">
+                                                                                                               <div>
+                                                                                                                  <fieldset>
+                                                                                                                     <legend>
+                                                                                                                        cybox properties
+                                                                                                                        (type: AddressObjectType)
+                                                                                                                        <span class="cyboxPropertiesSingleConstraint"> [category=ipv4-addr]</span></legend>
+                                                                                                                     <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                        <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Address_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">199.192.156.134</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                     </div>
+                                                                                                                  </fieldset>
+                                                                                                               </div>
+                                                                                                            </div>
+                                                                                                         </div>
+                                                                                                      </div>
+                                                                                                   </div>
+                                                                                                </div>
+                                                                                                <div class="contents relatedObjectContents relatedObject">
+                                                                                                   <div></div>
+                                                                                                </div>
+                                                                                             </div>
+                                                                                          </div>
+                                                                                       </div>
+                                                                                    </div>
+                                                                                 </div>
+                                                                              </div>
+                                                                           </div>
+                                                                        </div>
+                                                                        <div class="contents associatedObjectContents associatedObject">
+                                                                           <div></div>
+                                                                        </div>
+                                                                     </div>
+                                                                     <div class="container associatedObjectContainer associatedObject">
+                                                                        <div class="heading associatedObjectHeading associatedObject">
+                                                                           <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f</div>
+                                                                           <div class="expandableContainer expandableSeparate collapsed">
+                                                                              <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Utilized ○  AddressObjectType ○ example:Object-61aa225b-90ef-415c-8bbd-a17282e457c9 <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                              <div class="expandableContents">
+                                                                                 <div class="container objectContainer object">
+                                                                                    <div class="heading objectHeading object">
+                                                                                       <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f,example:Object-61aa225b-90ef-415c-8bbd-a17282e457c9</div>
+                                                                                    </div>
+                                                                                    <div class="contents objectContents object">
+                                                                                       <div>
+                                                                                          <fieldset>
+                                                                                             <legend>
+                                                                                                cybox properties
+                                                                                                (type: AddressObjectType)
+                                                                                                <span class="cyboxPropertiesSingleConstraint"> [category=ipv4-addr]</span></legend>
+                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Address_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">199.192.156.134</span><div class="cyboxPropertiesLink"></div>
+                                                                                                </div>
+                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                             </div>
+                                                                                          </fieldset>
+                                                                                       </div>
+                                                                                    </div>
+                                                                                 </div>
+                                                                              </div>
+                                                                           </div>
+                                                                        </div>
+                                                                        <div class="contents associatedObjectContents associatedObject">
+                                                                           <div></div>
+                                                                        </div>
+                                                                     </div>
+                                                                     <div class="container associatedObjectContainer associatedObject">
+                                                                        <div class="heading associatedObjectHeading associatedObject">
+                                                                           <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f</div>
+                                                                           <div class="expandableContainer expandableSeparate collapsed">
+                                                                              <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Utilized ○  URIObjectType ○ example:Object-568db11e-39ee-43d7-83d8-032bdec3801a <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                              <div class="expandableContents">
+                                                                                 <div class="container objectContainer object">
+                                                                                    <div class="heading objectHeading object">
+                                                                                       <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f,example:Object-568db11e-39ee-43d7-83d8-032bdec3801a</div>
+                                                                                    </div>
+                                                                                    <div class="contents objectContents object">
+                                                                                       <div>
+                                                                                          <fieldset>
+                                                                                             <legend>
+                                                                                                cybox properties
+                                                                                                (type: URIObjectType)
+                                                                                                <span class="cyboxPropertiesSingleConstraint"> [type=URL]</span></legend>
+                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">documents.myPicture.info</span><div class="cyboxPropertiesLink"></div>
+                                                                                                </div>
+                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                             </div>
+                                                                                          </fieldset>
+                                                                                       </div>
+                                                                                       <div class="container relatedObjects">
+                                                                                          <div class="heading relatedObjects">Related Objects
+                                                                                             
+                                                                                          </div>
+                                                                                          <div class="contents relatedObjects">
+                                                                                             <div class="container relatedObjectContainer relatedObject">
+                                                                                                <div class="heading relatedObjectHeading relatedObject">
+                                                                                                   <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f,example:Object-568db11e-39ee-43d7-83d8-032bdec3801a</div>
+                                                                                                   <div class="expandableContainer expandableSeparate collapsed">
+                                                                                                      <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Resolved_To ○  AddressObjectType ○ example:Object-80bea4d1-0e70-4a03-a54f-e40373bf94f1 <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                                      <div class="expandableContents">
+                                                                                                         <div class="container objectContainer object">
+                                                                                                            <div class="heading objectHeading object">
+                                                                                                               <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f,example:Object-568db11e-39ee-43d7-83d8-032bdec3801a,example:Object-80bea4d1-0e70-4a03-a54f-e40373bf94f1</div>
+                                                                                                            </div>
+                                                                                                            <div class="contents objectContents object">
+                                                                                                               <div>
+                                                                                                                  <fieldset>
+                                                                                                                     <legend>
+                                                                                                                        cybox properties
+                                                                                                                        (type: AddressObjectType)
+                                                                                                                        <span class="cyboxPropertiesSingleConstraint"> [category=ipv4-addr]</span></legend>
+                                                                                                                     <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                        <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Address_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">199.192.156.134</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                     </div>
+                                                                                                                  </fieldset>
+                                                                                                               </div>
+                                                                                                            </div>
+                                                                                                         </div>
+                                                                                                      </div>
+                                                                                                   </div>
+                                                                                                </div>
+                                                                                                <div class="contents relatedObjectContents relatedObject">
+                                                                                                   <div></div>
+                                                                                                </div>
+                                                                                             </div>
+                                                                                          </div>
+                                                                                       </div>
+                                                                                    </div>
+                                                                                 </div>
+                                                                              </div>
+                                                                           </div>
+                                                                        </div>
+                                                                        <div class="contents associatedObjectContents associatedObject">
+                                                                           <div></div>
+                                                                        </div>
+                                                                     </div>
+                                                                     <div class="container associatedObjectContainer associatedObject">
+                                                                        <div class="heading associatedObjectHeading associatedObject">
+                                                                           <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f</div>
+                                                                           <div class="expandableContainer expandableSeparate collapsed">
+                                                                              <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Utilized ○  AddressObjectType ○ example:Object-80bea4d1-0e70-4a03-a54f-e40373bf94f1 <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                              <div class="expandableContents">
+                                                                                 <div class="container objectContainer object">
+                                                                                    <div class="heading objectHeading object">
+                                                                                       <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f,example:Object-80bea4d1-0e70-4a03-a54f-e40373bf94f1</div>
+                                                                                    </div>
+                                                                                    <div class="contents objectContents object">
+                                                                                       <div>
+                                                                                          <fieldset>
+                                                                                             <legend>
+                                                                                                cybox properties
+                                                                                                (type: AddressObjectType)
+                                                                                                <span class="cyboxPropertiesSingleConstraint"> [category=ipv4-addr]</span></legend>
+                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Address_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">199.192.156.134</span><div class="cyboxPropertiesLink"></div>
+                                                                                                </div>
+                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                             </div>
+                                                                                          </fieldset>
+                                                                                       </div>
+                                                                                    </div>
+                                                                                 </div>
+                                                                              </div>
+                                                                           </div>
+                                                                        </div>
+                                                                        <div class="contents associatedObjectContents associatedObject">
+                                                                           <div></div>
+                                                                        </div>
+                                                                     </div>
+                                                                     <div class="container associatedObjectContainer associatedObject">
+                                                                        <div class="heading associatedObjectHeading associatedObject">
+                                                                           <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f</div>
+                                                                           <div class="expandableContainer expandableSeparate collapsed">
+                                                                              <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Utilized ○  URIObjectType ○ example:Object-af7cb3b6-d70b-4b3b-b24f-7cfad739710f <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                              <div class="expandableContents">
+                                                                                 <div class="container objectContainer object">
+                                                                                    <div class="heading objectHeading object">
+                                                                                       <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f,example:Object-af7cb3b6-d70b-4b3b-b24f-7cfad739710f</div>
+                                                                                    </div>
+                                                                                    <div class="contents objectContents object">
+                                                                                       <div>
+                                                                                          <fieldset>
+                                                                                             <legend>
+                                                                                                cybox properties
+                                                                                                (type: URIObjectType)
+                                                                                                <span class="cyboxPropertiesSingleConstraint"> [type=URL]</span></legend>
+                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">ftp.documents.myPicture.info</span><div class="cyboxPropertiesLink"></div>
+                                                                                                </div>
+                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                             </div>
+                                                                                          </fieldset>
+                                                                                       </div>
+                                                                                       <div class="container relatedObjects">
+                                                                                          <div class="heading relatedObjects">Related Objects
+                                                                                             
+                                                                                          </div>
+                                                                                          <div class="contents relatedObjects">
+                                                                                             <div class="container relatedObjectContainer relatedObject">
+                                                                                                <div class="heading relatedObjectHeading relatedObject">
+                                                                                                   <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f,example:Object-af7cb3b6-d70b-4b3b-b24f-7cfad739710f</div>
+                                                                                                   <div class="expandableContainer expandableSeparate collapsed">
+                                                                                                      <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Resolved_To ○  AddressObjectType ○ example:Object-5ceb9d54-24e2-4627-948d-6b92ac81962a <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                                                      <div class="expandableContents">
+                                                                                                         <div class="container objectContainer object">
+                                                                                                            <div class="heading objectHeading object">
+                                                                                                               <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f,example:Object-af7cb3b6-d70b-4b3b-b24f-7cfad739710f,example:Object-5ceb9d54-24e2-4627-948d-6b92ac81962a</div>
+                                                                                                            </div>
+                                                                                                            <div class="contents objectContents object">
+                                                                                                               <div>
+                                                                                                                  <fieldset>
+                                                                                                                     <legend>
+                                                                                                                        cybox properties
+                                                                                                                        (type: AddressObjectType)
+                                                                                                                        <span class="cyboxPropertiesSingleConstraint"> [category=ipv4-addr]</span></legend>
+                                                                                                                     <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                                        <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Address_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">199.192.156.134</span><div class="cyboxPropertiesLink"></div>
+                                                                                                                        </div>
+                                                                                                                        <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                                                     </div>
+                                                                                                                  </fieldset>
+                                                                                                               </div>
+                                                                                                            </div>
+                                                                                                         </div>
+                                                                                                      </div>
+                                                                                                   </div>
+                                                                                                </div>
+                                                                                                <div class="contents relatedObjectContents relatedObject">
+                                                                                                   <div></div>
+                                                                                                </div>
+                                                                                             </div>
+                                                                                          </div>
+                                                                                       </div>
+                                                                                    </div>
+                                                                                 </div>
+                                                                              </div>
+                                                                           </div>
+                                                                        </div>
+                                                                        <div class="contents associatedObjectContents associatedObject">
+                                                                           <div></div>
+                                                                        </div>
+                                                                     </div>
+                                                                     <div class="container associatedObjectContainer associatedObject">
+                                                                        <div class="heading associatedObjectHeading associatedObject">
+                                                                           <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f</div>
+                                                                           <div class="expandableContainer expandableSeparate collapsed">
+                                                                              <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Utilized ○  AddressObjectType ○ example:Object-5ceb9d54-24e2-4627-948d-6b92ac81962a <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                              <div class="expandableContents">
+                                                                                 <div class="container objectContainer object">
+                                                                                    <div class="heading objectHeading object">
+                                                                                       <div class="debug idStack">id stack: example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f,example:Object-5ceb9d54-24e2-4627-948d-6b92ac81962a</div>
+                                                                                    </div>
+                                                                                    <div class="contents objectContents object">
+                                                                                       <div>
+                                                                                          <fieldset>
+                                                                                             <legend>
+                                                                                                cybox properties
+                                                                                                (type: AddressObjectType)
+                                                                                                <span class="cyboxPropertiesSingleConstraint"> [category=ipv4-addr]</span></legend>
+                                                                                             <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                                <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Address_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">199.192.156.134</span><div class="cyboxPropertiesLink"></div>
+                                                                                                </div>
+                                                                                                <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                             </div>
+                                                                                          </fieldset>
+                                                                                       </div>
+                                                                                    </div>
+                                                                                 </div>
+                                                                              </div>
+                                                                           </div>
+                                                                        </div>
+                                                                        <div class="contents associatedObjectContents associatedObject">
+                                                                           <div></div>
+                                                                        </div>
+                                                                     </div>
+                                                                  </div>
+                                                               </div>
+                                                            </div>
+                                                         </div>
+                                                      </div>
+                                                   </div>
+                                                   <div></div>
+                                                </div>
+                                             </div>
+                                          </td>
+                                       </tr>
+                                    </tbody>
+                                 </table>
+                              </div>
+                           </div>
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR style="width:100%;font-style:italic;">
+                     <TD colspan="2">
+                        <div style="font-size:13px; font-style: italic; display:none;" id="8_ind_description">Test Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!! Test
+                           Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre
+                           Artifact Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre Artifact
+                           Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!!
+                           Test Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!! Test
+                           Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre
+                           Artifact Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre Artifact
+                           Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!!
+                           Test Malwawre Artifact Information!!!! 
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR class="">
+                     <TD>
+                        <div id="fileObjAtt" class="collapsibleLabel" style="cursor: pointer;" onclick="toggleDiv('700000000544','d1e555','d1e555-2')"><span id="d1e555" style="font-weight:bold; margin:5px; color:#BD9C8C;">+</span>example:Observable-066cef51-c886-432e-9a22-a17f57f3f3f2
+                        </div>
+                     </TD>
+                     <TD>
+                        <div style="cursor: pointer;" onclick="toggleDiv('700000000544','d1e555','d1e555-2')"><span id="d1e555-2" style="font-weight:bold; margin:5px; color:#BD9C8C;">+</span>URIObjectType
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR class="">
+                     <TD colspan="2">
+                        <div id="700000000544" class="collapsibleContent" style="overflow:hidden; display:none; padding:0px 7px;">
+                           <div id="example:Observable-066cef51-c886-432e-9a22-a17f57f3f3f2">
+                              <div class="debug idStack">id stack: example:Observable-066cef51-c886-432e-9a22-a17f57f3f3f2</div><br><div id="section">
+                                 <table class="one-column-emphasis">
+                                    <colgroup>
+                                       <col class="oce-first-obs">
+                                    </colgroup>
+                                    <tbody>
+                                       <tr>
+                                          <td>
+                                             <div class="container objectContainer object" id="example:Object-41b220d8-4c45-48de-9d08-30d661b2dc8e">
+                                                <div class="heading objectHeading object"> URIObjectType ○ <span class="inlineObject">example:Object-41b220d8-4c45-48de-9d08-30d661b2dc8e</span> <span class="debug inlineOrByReferenceLabel">(inline object)</span><div class="debug idStack">id stack: example:Observable-066cef51-c886-432e-9a22-a17f57f3f3f2,example:Object-41b220d8-4c45-48de-9d08-30d661b2dc8e</div>
+                                                </div>
+                                                <div class="contents objectContents object">
+                                                   <div>
+                                                      <fieldset>
+                                                         <legend>
+                                                            cybox properties
+                                                            (type: URIObjectType)
+                                                            
+                                                         </legend>
+                                                         <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                            <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">www.documents.myPicture.info</span><div class="cyboxPropertiesLink"></div>
+                                                            </div>
+                                                            <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                         </div>
+                                                      </fieldset>
+                                                   </div>
+                                                   <div class="container relatedObjects">
+                                                      <div class="heading relatedObjects">Related Objects
+                                                         
+                                                      </div>
+                                                      <div class="contents relatedObjects">
+                                                         <div class="container relatedObjectContainer relatedObject">
+                                                            <div class="heading relatedObjectHeading relatedObject">
+                                                               <div class="debug idStack">id stack: example:Observable-066cef51-c886-432e-9a22-a17f57f3f3f2,example:Object-41b220d8-4c45-48de-9d08-30d661b2dc8e</div>
+                                                               <div class="expandableContainer expandableSeparate collapsed">
+                                                                  <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Resolved_To ○  AddressObjectType ○ example:Object-61aa225b-90ef-415c-8bbd-a17282e457c9 <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                  <div class="expandableContents">
+                                                                     <div class="container objectContainer object">
+                                                                        <div class="heading objectHeading object">
+                                                                           <div class="debug idStack">id stack: example:Observable-066cef51-c886-432e-9a22-a17f57f3f3f2,example:Object-41b220d8-4c45-48de-9d08-30d661b2dc8e,example:Object-61aa225b-90ef-415c-8bbd-a17282e457c9</div>
+                                                                        </div>
+                                                                        <div class="contents objectContents object">
+                                                                           <div>
+                                                                              <fieldset>
+                                                                                 <legend>
+                                                                                    cybox properties
+                                                                                    (type: AddressObjectType)
+                                                                                    <span class="cyboxPropertiesSingleConstraint"> [category=ipv4-addr]</span></legend>
+                                                                                 <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                    <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Address_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">199.192.156.134</span><div class="cyboxPropertiesLink"></div>
+                                                                                    </div>
+                                                                                    <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                 </div>
+                                                                              </fieldset>
+                                                                           </div>
+                                                                        </div>
+                                                                     </div>
+                                                                  </div>
+                                                               </div>
+                                                            </div>
+                                                            <div class="contents relatedObjectContents relatedObject">
+                                                               <div></div>
+                                                            </div>
+                                                         </div>
+                                                      </div>
+                                                   </div>
+                                                </div>
+                                             </div>
+                                          </td>
+                                       </tr>
+                                    </tbody>
+                                 </table>
+                              </div>
+                           </div>
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR style="width:100%;font-style:italic;">
+                     <TD colspan="2">
+                        <div style="font-size:13px; font-style: italic; display:none;" id="9_ind_description">Test Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!! Test
+                           Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre
+                           Artifact Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre Artifact
+                           Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!!
+                           Test Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!! Test
+                           Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre
+                           Artifact Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre Artifact
+                           Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!!
+                           Test Malwawre Artifact Information!!!! 
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR class="">
+                     <TD>
+                        <div id="fileObjAtt" class="collapsibleLabel" style="cursor: pointer;" onclick="toggleDiv('700000000567','d1e578','d1e578-2')"><span id="d1e578" style="font-weight:bold; margin:5px; color:#BD9C8C;">+</span>example:Observable-4e05804c-f552-44e1-9793-ff4bb7f88f9c
+                        </div>
+                     </TD>
+                     <TD>
+                        <div style="cursor: pointer;" onclick="toggleDiv('700000000567','d1e578','d1e578-2')"><span id="d1e578-2" style="font-weight:bold; margin:5px; color:#BD9C8C;">+</span>AddressObjectType
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR class="">
+                     <TD colspan="2">
+                        <div id="700000000567" class="collapsibleContent" style="overflow:hidden; display:none; padding:0px 7px;">
+                           <div id="example:Observable-4e05804c-f552-44e1-9793-ff4bb7f88f9c">
+                              <div class="debug idStack">id stack: example:Observable-4e05804c-f552-44e1-9793-ff4bb7f88f9c</div><br><div id="section">
+                                 <table class="one-column-emphasis">
+                                    <colgroup>
+                                       <col class="oce-first-obs">
+                                    </colgroup>
+                                    <tbody>
+                                       <tr>
+                                          <td>
+                                             <div class="container objectContainer object" id="example:Object-61aa225b-90ef-415c-8bbd-a17282e457c9">
+                                                <div class="heading objectHeading object"> AddressObjectType ○ <span class="inlineObject">example:Object-61aa225b-90ef-415c-8bbd-a17282e457c9</span> <span class="debug inlineOrByReferenceLabel">(inline object)</span><div class="debug idStack">id stack: example:Observable-4e05804c-f552-44e1-9793-ff4bb7f88f9c,example:Object-61aa225b-90ef-415c-8bbd-a17282e457c9</div>
+                                                </div>
+                                                <div class="contents objectContents object">
+                                                   <div>
+                                                      <fieldset>
+                                                         <legend>
+                                                            cybox properties
+                                                            (type: AddressObjectType)
+                                                            <span class="cyboxPropertiesSingleConstraint"> [category=ipv4-addr]</span></legend>
+                                                         <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                            <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Address_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">199.192.156.134</span><div class="cyboxPropertiesLink"></div>
+                                                            </div>
+                                                            <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                         </div>
+                                                      </fieldset>
+                                                   </div>
+                                                </div>
+                                             </div>
+                                          </td>
+                                       </tr>
+                                    </tbody>
+                                 </table>
+                              </div>
+                           </div>
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR style="width:100%;font-style:italic;">
+                     <TD colspan="2">
+                        <div style="font-size:13px; font-style: italic; display:none;" id="10_ind_description">Test Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!! Test
+                           Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre
+                           Artifact Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre Artifact
+                           Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!!
+                           Test Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!! Test
+                           Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre
+                           Artifact Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre Artifact
+                           Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!!
+                           Test Malwawre Artifact Information!!!! 
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR class="">
+                     <TD>
+                        <div id="fileObjAtt" class="collapsibleLabel" style="cursor: pointer;" onclick="toggleDiv('700000000581','d1e592','d1e592-2')"><span id="d1e592" style="font-weight:bold; margin:5px; color:#BD9C8C;">+</span>example:Observable-75ce59ad-1f01-4eae-9ecc-0b22c4c24ce7
+                        </div>
+                     </TD>
+                     <TD>
+                        <div style="cursor: pointer;" onclick="toggleDiv('700000000581','d1e592','d1e592-2')"><span id="d1e592-2" style="font-weight:bold; margin:5px; color:#BD9C8C;">+</span>URIObjectType
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR class="">
+                     <TD colspan="2">
+                        <div id="700000000581" class="collapsibleContent" style="overflow:hidden; display:none; padding:0px 7px;">
+                           <div id="example:Observable-75ce59ad-1f01-4eae-9ecc-0b22c4c24ce7">
+                              <div class="debug idStack">id stack: example:Observable-75ce59ad-1f01-4eae-9ecc-0b22c4c24ce7</div><br><div id="section">
+                                 <table class="one-column-emphasis">
+                                    <colgroup>
+                                       <col class="oce-first-obs">
+                                    </colgroup>
+                                    <tbody>
+                                       <tr>
+                                          <td>
+                                             <div class="container objectContainer object" id="example:Object-568db11e-39ee-43d7-83d8-032bdec3801a">
+                                                <div class="heading objectHeading object"> URIObjectType ○ <span class="inlineObject">example:Object-568db11e-39ee-43d7-83d8-032bdec3801a</span> <span class="debug inlineOrByReferenceLabel">(inline object)</span><div class="debug idStack">id stack: example:Observable-75ce59ad-1f01-4eae-9ecc-0b22c4c24ce7,example:Object-568db11e-39ee-43d7-83d8-032bdec3801a</div>
+                                                </div>
+                                                <div class="contents objectContents object">
+                                                   <div>
+                                                      <fieldset>
+                                                         <legend>
+                                                            cybox properties
+                                                            (type: URIObjectType)
+                                                            <span class="cyboxPropertiesSingleConstraint"> [type=URL]</span></legend>
+                                                         <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                            <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">documents.myPicture.info</span><div class="cyboxPropertiesLink"></div>
+                                                            </div>
+                                                            <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                         </div>
+                                                      </fieldset>
+                                                   </div>
+                                                   <div class="container relatedObjects">
+                                                      <div class="heading relatedObjects">Related Objects
+                                                         
+                                                      </div>
+                                                      <div class="contents relatedObjects">
+                                                         <div class="container relatedObjectContainer relatedObject">
+                                                            <div class="heading relatedObjectHeading relatedObject">
+                                                               <div class="debug idStack">id stack: example:Observable-75ce59ad-1f01-4eae-9ecc-0b22c4c24ce7,example:Object-568db11e-39ee-43d7-83d8-032bdec3801a</div>
+                                                               <div class="expandableContainer expandableSeparate collapsed">
+                                                                  <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Resolved_To ○  AddressObjectType ○ example:Object-80bea4d1-0e70-4a03-a54f-e40373bf94f1 <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                  <div class="expandableContents">
+                                                                     <div class="container objectContainer object">
+                                                                        <div class="heading objectHeading object">
+                                                                           <div class="debug idStack">id stack: example:Observable-75ce59ad-1f01-4eae-9ecc-0b22c4c24ce7,example:Object-568db11e-39ee-43d7-83d8-032bdec3801a,example:Object-80bea4d1-0e70-4a03-a54f-e40373bf94f1</div>
+                                                                        </div>
+                                                                        <div class="contents objectContents object">
+                                                                           <div>
+                                                                              <fieldset>
+                                                                                 <legend>
+                                                                                    cybox properties
+                                                                                    (type: AddressObjectType)
+                                                                                    <span class="cyboxPropertiesSingleConstraint"> [category=ipv4-addr]</span></legend>
+                                                                                 <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                    <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Address_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">199.192.156.134</span><div class="cyboxPropertiesLink"></div>
+                                                                                    </div>
+                                                                                    <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                 </div>
+                                                                              </fieldset>
+                                                                           </div>
+                                                                        </div>
+                                                                     </div>
+                                                                  </div>
+                                                               </div>
+                                                            </div>
+                                                            <div class="contents relatedObjectContents relatedObject">
+                                                               <div></div>
+                                                            </div>
+                                                         </div>
+                                                      </div>
+                                                   </div>
+                                                </div>
+                                             </div>
+                                          </td>
+                                       </tr>
+                                    </tbody>
+                                 </table>
+                              </div>
+                           </div>
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR>
+                     <TD colspan="2">
+                        <hr>
+                     </TD>
+                  </TR>
+                  <TR style="width:100%;font-style:italic;">
+                     <TD><strong>TEST3:indicator-f205f08f-818b-4670-8491-45fad9e37ee4</strong><div style="font-size:13px; font-style: italic; display:none;" id="11_description">This collection of observables were observed as part of the widespread "Iran-Oil"
+                           (among many other names used) attack campaign in March 2012
+                        </div><a style="cursor:pointer; color:grey;" onclick="showLongIndicatorDescription(this, 11);">
+                           (Show Long Description)
+                           </a></TD>
+                     <TD>
+                        (Domain Watchlist)
+                        
+                     </TD>
+                  </TR>
+                  <TR style="width:100%;font-style:italic;">
+                     <TD colspan="2">
+                        <div style="font-size:13px; font-style: italic; display:none;" id="11_ind_description">Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!!
+                           Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!!
+                           Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!!
+                           Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!!
+                           Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!!
+                           Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!!
+                           
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR class="">
+                     <TD>
+                        <div id="fileObjAtt" class="collapsibleLabel" style="cursor: pointer;" onclick="toggleDiv('700000000613','d1e624','d1e624-2')"><span id="d1e624" style="font-weight:bold; margin:5px; color:#BD9C8C;">+</span>example:Observable-1ea53b14-8fe9-467b-a298-62d9684e797d
+                        </div>
+                     </TD>
+                     <TD>
+                        <div style="cursor: pointer;" onclick="toggleDiv('700000000613','d1e624','d1e624-2')"><span id="d1e624-2" style="font-weight:bold; margin:5px; color:#BD9C8C;">+</span>AddressObjectType
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR class="">
+                     <TD colspan="2">
+                        <div id="700000000613" class="collapsibleContent" style="overflow:hidden; display:none; padding:0px 7px;">
+                           <div id="example:Observable-1ea53b14-8fe9-467b-a298-62d9684e797d">
+                              <div class="debug idStack">id stack: example:Observable-1ea53b14-8fe9-467b-a298-62d9684e797d</div><br><div id="section">
+                                 <table class="one-column-emphasis">
+                                    <colgroup>
+                                       <col class="oce-first-obs">
+                                    </colgroup>
+                                    <tbody>
+                                       <tr>
+                                          <td>
+                                             <div class="container objectContainer object" id="example:Object-80bea4d1-0e70-4a03-a54f-e40373bf94f1">
+                                                <div class="heading objectHeading object"> AddressObjectType ○ <span class="inlineObject">example:Object-80bea4d1-0e70-4a03-a54f-e40373bf94f1</span> <span class="debug inlineOrByReferenceLabel">(inline object)</span><div class="debug idStack">id stack: example:Observable-1ea53b14-8fe9-467b-a298-62d9684e797d,example:Object-80bea4d1-0e70-4a03-a54f-e40373bf94f1</div>
+                                                </div>
+                                                <div class="contents objectContents object">
+                                                   <div>
+                                                      <fieldset>
+                                                         <legend>
+                                                            cybox properties
+                                                            (type: AddressObjectType)
+                                                            <span class="cyboxPropertiesSingleConstraint"> [category=ipv4-addr]</span></legend>
+                                                         <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                            <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Address_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">199.192.156.134</span><div class="cyboxPropertiesLink"></div>
+                                                            </div>
+                                                            <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                         </div>
+                                                      </fieldset>
+                                                   </div>
+                                                </div>
+                                             </div>
+                                          </td>
+                                       </tr>
+                                    </tbody>
+                                 </table>
+                              </div>
+                           </div>
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR style="width:100%;font-style:italic;">
+                     <TD colspan="2">
+                        <div style="font-size:13px; font-style: italic; display:none;" id="12_ind_description">Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!!
+                           Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!!
+                           Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!!
+                           Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!!
+                           Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!!
+                           Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!!
+                           
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR class="">
+                     <TD>
+                        <div id="fileObjAtt" class="collapsibleLabel" style="cursor: pointer;" onclick="toggleDiv('700000000627','d1e638','d1e638-2')"><span id="d1e638" style="font-weight:bold; margin:5px; color:#BD9C8C;">+</span>example:Observable-f6c8ee75-ee7e-4490-bd5d-0661d0db7264
+                        </div>
+                     </TD>
+                     <TD>
+                        <div style="cursor: pointer;" onclick="toggleDiv('700000000627','d1e638','d1e638-2')"><span id="d1e638-2" style="font-weight:bold; margin:5px; color:#BD9C8C;">+</span>URIObjectType
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR class="">
+                     <TD colspan="2">
+                        <div id="700000000627" class="collapsibleContent" style="overflow:hidden; display:none; padding:0px 7px;">
+                           <div id="example:Observable-f6c8ee75-ee7e-4490-bd5d-0661d0db7264">
+                              <div class="debug idStack">id stack: example:Observable-f6c8ee75-ee7e-4490-bd5d-0661d0db7264</div><br><div id="section">
+                                 <table class="one-column-emphasis">
+                                    <colgroup>
+                                       <col class="oce-first-obs">
+                                    </colgroup>
+                                    <tbody>
+                                       <tr>
+                                          <td>
+                                             <div class="container objectContainer object" id="example:Object-af7cb3b6-d70b-4b3b-b24f-7cfad739710f">
+                                                <div class="heading objectHeading object"> URIObjectType ○ <span class="inlineObject">example:Object-af7cb3b6-d70b-4b3b-b24f-7cfad739710f</span> <span class="debug inlineOrByReferenceLabel">(inline object)</span><div class="debug idStack">id stack: example:Observable-f6c8ee75-ee7e-4490-bd5d-0661d0db7264,example:Object-af7cb3b6-d70b-4b3b-b24f-7cfad739710f</div>
+                                                </div>
+                                                <div class="contents objectContents object">
+                                                   <div>
+                                                      <fieldset>
+                                                         <legend>
+                                                            cybox properties
+                                                            (type: URIObjectType)
+                                                            <span class="cyboxPropertiesSingleConstraint"> [type=URL]</span></legend>
+                                                         <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                            <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">ftp.documents.myPicture.info</span><div class="cyboxPropertiesLink"></div>
+                                                            </div>
+                                                            <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                         </div>
+                                                      </fieldset>
+                                                   </div>
+                                                   <div class="container relatedObjects">
+                                                      <div class="heading relatedObjects">Related Objects
+                                                         
+                                                      </div>
+                                                      <div class="contents relatedObjects">
+                                                         <div class="container relatedObjectContainer relatedObject">
+                                                            <div class="heading relatedObjectHeading relatedObject">
+                                                               <div class="debug idStack">id stack: example:Observable-f6c8ee75-ee7e-4490-bd5d-0661d0db7264,example:Object-af7cb3b6-d70b-4b3b-b24f-7cfad739710f</div>
+                                                               <div class="expandableContainer expandableSeparate collapsed">
+                                                                  <div class="expandableToggle objectReference" onclick="toggle(this.parentNode)">Resolved_To ○  AddressObjectType ○ example:Object-5ceb9d54-24e2-4627-948d-6b92ac81962a <span class="debug inlineOrByReferenceLabel">(reference by idref)</span></div>
+                                                                  <div class="expandableContents">
+                                                                     <div class="container objectContainer object">
+                                                                        <div class="heading objectHeading object">
+                                                                           <div class="debug idStack">id stack: example:Observable-f6c8ee75-ee7e-4490-bd5d-0661d0db7264,example:Object-af7cb3b6-d70b-4b3b-b24f-7cfad739710f,example:Object-5ceb9d54-24e2-4627-948d-6b92ac81962a</div>
+                                                                        </div>
+                                                                        <div class="contents objectContents object">
+                                                                           <div>
+                                                                              <fieldset>
+                                                                                 <legend>
+                                                                                    cybox properties
+                                                                                    (type: AddressObjectType)
+                                                                                    <span class="cyboxPropertiesSingleConstraint"> [category=ipv4-addr]</span></legend>
+                                                                                 <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                                                    <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Address_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">199.192.156.134</span><div class="cyboxPropertiesLink"></div>
+                                                                                    </div>
+                                                                                    <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                                                 </div>
+                                                                              </fieldset>
+                                                                           </div>
+                                                                        </div>
+                                                                     </div>
+                                                                  </div>
+                                                               </div>
+                                                            </div>
+                                                            <div class="contents relatedObjectContents relatedObject">
+                                                               <div></div>
+                                                            </div>
+                                                         </div>
+                                                      </div>
+                                                   </div>
+                                                </div>
+                                             </div>
+                                          </td>
+                                       </tr>
+                                    </tbody>
+                                 </table>
+                              </div>
+                           </div>
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR style="width:100%;font-style:italic;">
+                     <TD colspan="2">
+                        <div style="font-size:13px; font-style: italic; display:none;" id="13_ind_description">Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!!
+                           Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!!
+                           Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!!
+                           Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!!
+                           Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!!
+                           Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!!
+                           
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR class="">
+                     <TD>
+                        <div id="fileObjAtt" class="collapsibleLabel" style="cursor: pointer;" onclick="toggleDiv('700000000650','d1e661','d1e661-2')"><span id="d1e661" style="font-weight:bold; margin:5px; color:#BD9C8C;">+</span>example:Observable-c78c0a83-6d14-45f8-827f-f758f0cd11ea
+                        </div>
+                     </TD>
+                     <TD>
+                        <div style="cursor: pointer;" onclick="toggleDiv('700000000650','d1e661','d1e661-2')"><span id="d1e661-2" style="font-weight:bold; margin:5px; color:#BD9C8C;">+</span>AddressObjectType
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR class="">
+                     <TD colspan="2">
+                        <div id="700000000650" class="collapsibleContent" style="overflow:hidden; display:none; padding:0px 7px;">
+                           <div id="example:Observable-c78c0a83-6d14-45f8-827f-f758f0cd11ea">
+                              <div class="debug idStack">id stack: example:Observable-c78c0a83-6d14-45f8-827f-f758f0cd11ea</div><br><div id="section">
+                                 <table class="one-column-emphasis">
+                                    <colgroup>
+                                       <col class="oce-first-obs">
+                                    </colgroup>
+                                    <tbody>
+                                       <tr>
+                                          <td>
+                                             <div class="container objectContainer object" id="example:Object-5ceb9d54-24e2-4627-948d-6b92ac81962a">
+                                                <div class="heading objectHeading object"> AddressObjectType ○ <span class="inlineObject">example:Object-5ceb9d54-24e2-4627-948d-6b92ac81962a</span> <span class="debug inlineOrByReferenceLabel">(inline object)</span><div class="debug idStack">id stack: example:Observable-c78c0a83-6d14-45f8-827f-f758f0cd11ea,example:Object-5ceb9d54-24e2-4627-948d-6b92ac81962a</div>
+                                                </div>
+                                                <div class="contents objectContents object">
+                                                   <div>
+                                                      <fieldset>
+                                                         <legend>
+                                                            cybox properties
+                                                            (type: AddressObjectType)
+                                                            <span class="cyboxPropertiesSingleConstraint"> [category=ipv4-addr]</span></legend>
+                                                         <div class="container cyboxPropertiesContainer cyboxProperties">
+                                                            <div class="heading cyboxPropertiesHeading cyboxProperties"><span class="cyboxPropertiesName">Address_Value</span><span class="cyboxPropertiesConstraints"><span class="cyboxPropertiesSingleConstraint"> [condition=Equals]</span></span><span class="cyboxPropertiesNameValueSeparator"> → </span><span class="cyboxPropertiesValue">199.192.156.134</span><div class="cyboxPropertiesLink"></div>
+                                                            </div>
+                                                            <div class="contents cyboxPropertiesContents cyboxProperties"></div>
+                                                         </div>
+                                                      </fieldset>
+                                                   </div>
+                                                </div>
+                                             </div>
+                                          </td>
+                                       </tr>
+                                    </tbody>
+                                 </table>
+                              </div>
+                           </div>
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR style="width:100%;font-style:italic;">
+                     <TD colspan="2">
+                        <div style="font-size:13px; font-style: italic; display:none;" id="14_ind_description">Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!!
+                           Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!!
+                           Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!!
+                           Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!!
+                           Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!!
+                           Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!!
+                           
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR class="">
+                     <TD>
+                        <div id="fileObjAtt" class="collapsibleLabel" style="cursor: pointer;" onclick="toggleDiv('700000000664','d1e676','d1e676-2')"><span id="d1e676" style="font-weight:bold; margin:5px; color:#BD9C8C;">+</span>example:Observable-47d6a950-884d-46b5-9938-ac5555065a81
+                        </div>
+                     </TD>
+                     <TD>
+                        <div style="cursor: pointer;" onclick="toggleDiv('700000000664','d1e676','d1e676-2')"><span id="d1e676-2" style="font-weight:bold; margin:5px; color:#BD9C8C;">+</span>
+                           Other
+                           
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR class="">
+                     <TD colspan="2">
+                        <div id="700000000664" class="collapsibleContent" style="overflow:hidden; display:none; padding:0px 7px;">
+                           <div id="example:Observable-47d6a950-884d-46b5-9938-ac5555065a81">
+                              <div class="debug idStack">id stack: example:Observable-47d6a950-884d-46b5-9938-ac5555065a81</div><br><div id="section">
+                                 <table class="one-column-emphasis">
+                                    <colgroup>
+                                       <col class="oce-first-obs">
+                                    </colgroup>
+                                    <tbody>
+                                       <tr>
+                                          <td></td>
+                                       </tr>
+                                    </tbody>
+                                 </table>
+                              </div>
+                           </div>
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR style="width:100%;font-style:italic;">
+                     <TD colspan="2">
+                        <div style="font-size:13px; font-style: italic; display:none;" id="15_ind_description">Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!!
+                           Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!!
+                           Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!!
+                           Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!!
+                           Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!!
+                           Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!!
+                           
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR class="">
+                     <TD>
+                        <div id="fileObjAtt" class="collapsibleLabel" style="cursor: pointer;" onclick="toggleDiv('700000000698','d1e712','d1e712-2')"><span id="d1e712" style="font-weight:bold; margin:5px; color:#BD9C8C;">+</span>example:Observable-80594430-7567-4402-88a4-05d556b21884
+                        </div>
+                     </TD>
+                     <TD>
+                        <div style="cursor: pointer;" onclick="toggleDiv('700000000698','d1e712','d1e712-2')"><span id="d1e712-2" style="font-weight:bold; margin:5px; color:#BD9C8C;">+</span>
+                           Other
+                           
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR class="">
+                     <TD colspan="2">
+                        <div id="700000000698" class="collapsibleContent" style="overflow:hidden; display:none; padding:0px 7px;">
+                           <div id="example:Observable-80594430-7567-4402-88a4-05d556b21884">
+                              <div class="debug idStack">id stack: example:Observable-80594430-7567-4402-88a4-05d556b21884</div><br><div id="section">
+                                 <table class="one-column-emphasis">
+                                    <colgroup>
+                                       <col class="oce-first-obs">
+                                    </colgroup>
+                                    <tbody>
+                                       <tr>
+                                          <td></td>
+                                       </tr>
+                                    </tbody>
+                                 </table>
+                              </div>
+                           </div>
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR style="width:100%;font-style:italic;">
+                     <TD colspan="2">
+                        <div style="font-size:13px; font-style: italic; display:none;" id="16_ind_description">Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!!
+                           Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!!
+                           Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!!
+                           Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!!
+                           Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!!
+                           Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!!
+                           
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR class="">
+                     <TD>
+                        <div id="fileObjAtt" class="collapsibleLabel" style="cursor: pointer;" onclick="toggleDiv('700000000732','d1e748','d1e748-2')"><span id="d1e748" style="font-weight:bold; margin:5px; color:#BD9C8C;">+</span>example:Observable-7d932074-fded-4056-870e-dd51980501d4
+                        </div>
+                     </TD>
+                     <TD>
+                        <div style="cursor: pointer;" onclick="toggleDiv('700000000732','d1e748','d1e748-2')"><span id="d1e748-2" style="font-weight:bold; margin:5px; color:#BD9C8C;">+</span>
+                           Other
+                           
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR class="">
+                     <TD colspan="2">
+                        <div id="700000000732" class="collapsibleContent" style="overflow:hidden; display:none; padding:0px 7px;">
+                           <div id="example:Observable-7d932074-fded-4056-870e-dd51980501d4">
+                              <div class="debug idStack">id stack: example:Observable-7d932074-fded-4056-870e-dd51980501d4</div><br><div id="section">
+                                 <table class="one-column-emphasis">
+                                    <colgroup>
+                                       <col class="oce-first-obs">
+                                    </colgroup>
+                                    <tbody>
+                                       <tr>
+                                          <td></td>
+                                       </tr>
+                                    </tbody>
+                                 </table>
+                              </div>
+                           </div>
+                        </div>
+                     </TD>
+                  </TR>
+                  <TR>
+                     <TD colspan="2">
+                        <hr>
+                     </TD>
+                  </TR>
+               </TBODY>
+            </TABLE>
+         </div>
+      </div>
+   </body>
+</html>

--- a/scripts/cybox_to_html/working_set_examples/CybOX_Iran-Oil_Dynamic-Taxii-Stix-Example.xml
+++ b/scripts/cybox_to_html/working_set_examples/CybOX_Iran-Oil_Dynamic-Taxii-Stix-Example.xml
@@ -1,0 +1,503 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<taxii:Inbox_Message xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:taxii="http://taxii.mitre.org/messages/taxii_xml_binding-1"
+    xmlns:cyboxCommon="http://cybox.mitre.org/common-2"
+    xmlns:cybox="http://cybox.mitre.org/cybox-2"
+    xmlns:cyboxVocabs="http://cybox.mitre.org/default_vocabularies-2"
+    xmlns:AddrObj="http://cybox.mitre.org/objects#AddressObject-2" 
+    xmlns:EmailMessageObj="http://cybox.mitre.org/objects#EmailMessageObject-2"  
+    xmlns:URIObj="http://cybox.mitre.org/objects#URIObject-2"
+    xmlns:FileObj="http://cybox.mitre.org/objects#FileObject-2"  
+    xmlns:indicator="http://stix.mitre.org/Indicator-2"
+    xmlns:stix="http://stix.mitre.org/stix-1"
+    xmlns:stixCommon="http://stix.mitre.org/common-1"
+    xmlns:stixVocabs="http://stix.mitre.org/default_vocabularies-1" 
+    xmlns:tlpMarking="http://data-marking.mitre.org/extensions/MarkingStructure#TLP-1"
+    xmlns:simpleMarking="http://data-marking.mitre.org/extensions/MarkingStructure#Simple-1" 
+    xmlns:marking="http://data-marking.mitre.org/Marking-1"
+    xmlns:CISCP="http://www.us-cert.gov/ciscp"
+    xsi:schemaLocation="http://taxii.mitre.org/messages/taxii_xml_binding-1 http://taxii.mitre.org/specifications/version1.0/xml1.0/TAXII_XMLMessageBinding_Schema.xsd
+        http://cybox.mitre.org/cybox-2 http://cybox.mitre.org/XMLSchema/core/2.0/cybox_core.xsd
+        http://cybox.mitre.org/default_vocabularies-2 http://cybox.mitre.org/XMLSchema/default_vocabularies/2.0.0/cybox_default_vocabularies.xsd
+        http://cybox.mitre.org/objects#AddressObject-2 http://cybox.mitre.org/XMLSchema/objects/Address/2.0/Address_Object.xsd
+        http://cybox.mitre.org/objects#EmailMessageObject-2 http://cybox.mitre.org/XMLSchema/objects/Email_Message/2.0/Email_Message_Object.xsd
+        http://cybox.mitre.org/objects#FileObject-2 http://cybox.mitre.org/XMLSchema/objects/File/2.0/File_Object.xsd
+        http://cybox.mitre.org/objects#MutexObject-2 http://cybox.mitre.org/XMLSchema/objects/Mutex/2.0/Mutex_Object.xsd
+        http://cybox.mitre.org/objects#URIObj-2 http://cybox.mitre.org/XMLSchema/objects/URI/2.0/URI_Object.xsd
+        http://cybox.mitre.org/objects#WinRegistryKeyObject-2 http://cybox.mitre.org/XMLSchema/objects/Win_Registry_Key/2.0/Win_Registry_Key_Object.xsd
+        http://stix.mitre.org/default_vocabularies-1 http://stix.mitre.org/XMLSchema/default_vocabularies/1.0.0/stix_default_vocabularies.xsd
+        http://stix.mitre.org/Indicator-2 http://stix.mitre.org/XMLSchema/indicator/2.0/indicator.xsd
+        http://stix.mitre.org/common-1 http://stix.mitre.org/XMLSchema/common/1.0/stix_common.xsd
+        http://stix.mitre.org/extensions/Identity#CIQIdentity3.0-1 http://stix.mitre.org/XMLSchema/extensions/identity/ciq_identity_3.0/1.0/ciq_identity_3.0.xsd
+        http://data-marking.mitre.org/extensions/MarkingStructure#Simple-1 http://stix.mitre.org/XMLSchema/extensions/marking/simple_marking/1.0/simple_marking.xsd
+        http://data-marking.mitre.org/Marking-1 http://stix.mitre.org/XMLSchema/data_marking/1.0/data_marking.xsd
+        http://data-marking.mitre.org/extensions/MarkingStructure#TLP-1 http://stix.mitre.org/XMLSchema/extensions/marking/tlp/1.0/tlp.xsd
+        urn:oasis:names:tc:ciq:xnl:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xNL.xsd
+        urn:oasis:names:tc:ciq:xpil:3 http://stix.mitre.org/XMLSchema/external/oasis_ciq_3.0/xPIL.xsd"
+    message_id='1564343186463486'>
+
+
+    <taxii:Content_Block>
+        <taxii:Content_Binding>urn:stix.mitre.org:xml:1.0</taxii:Content_Binding>
+        <taxii:Content>
+            <stix:STIX_Package id="Test Stix and Taxii" version="1.0">
+                <stix:STIX_Header>
+                    <stix:Title>Iran-Oil Stix Package</stix:Title>
+                    <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Threat Actor Characterization</stix:Package_Intent>
+                    <stix:Description>This collection of observables were observed as part of the widespread "Iran-Oil" (among many other names used) attack campaign in March 2012</stix:Description>
+                    <stix:Handling>
+                        <marking:Marking>
+                            <marking:Controlled_Structure>//node()</marking:Controlled_Structure>
+                            <marking:Marking_Structure color="AMBER" xsi:type="tlpMarking:TLPMarkingStructureType" />
+                        </marking:Marking>
+                        <marking:Marking>
+                            <marking:Controlled_Structure>//node()</marking:Controlled_Structure>
+                            <marking:Marking_Structure xsi:type="simpleMarking:SimpleMarkingStructureType">
+                                <simpleMarking:Statement>FOUO</simpleMarking:Statement>
+                            </marking:Marking_Structure>
+                        </marking:Marking>
+                    </stix:Handling>
+                    <stix:Information_Source>
+                        <stixCommon:Time>
+                            <cyboxCommon:Produced_Time>2013-07-16T16:04:00</cyboxCommon:Produced_Time>
+                        </stixCommon:Time>
+                    </stix:Information_Source>
+                </stix:STIX_Header>
+                <stix:Indicators>
+                    <stix:Indicator id="TEST:indicator-f205f08f-818b-4670-8491-45fad9e37ee4" version="2.0" xsi:type="indicator:IndicatorType">
+                        <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.0">Malicious E-mail</indicator:Type>
+                        <indicator:Description>Test Email Description!! Test Email Description!! Test Email Description!! Test Email Description!! Test Email Description!! Test Email Description!! Test Email Description!! Test Email Description!! Test Email Description!! Test Email Description!! Test Email Description!! Test Email Description!! Test Email Description!! Test Email Description!! Test Email Description!! Test Email Description!! Test Email Description!! Test Email Description!! Test Email Description!! Test Email Description!! Test Email Description!! Test Email Description!! Test Email Description!! Test Email Description!! Test Email Description!! </indicator:Description>
+                        <!-- This collection of observables were observed as part of the widespread "Iran-Oil" (among many other names used) attack campaign in March 2012 -->
+                        <indicator:Observable id="example:Observable-1a937ec2-90ab-4e0e-a37c-db9b2e66a58e">
+                            <!-- Receive "Iran-Oil" attack campaign email message -->
+                            <cybox:Event>
+                                <cybox:Type xsi:type="cyboxVocabs:EventTypeVocab-1.0">Email Ops</cybox:Type>
+                                <cybox:Description>Receive "Iran-Oil" attack campaign email message.</cybox:Description>
+                                <cybox:Actions>
+                                    <cybox:Action>
+                                        <cybox:Type xsi:type="cyboxVocabs:ActionTypeVocab-1.0">Receive</cybox:Type>
+                                        <cybox:Associated_Objects>
+                                            <cybox:Associated_Object id="example:Object-51359587-f201-4383-b032-5a64522fcd7d">
+                                                <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
+                                                    <EmailMessageObj:Header>
+                                                        <EmailMessageObj:To>
+                                                            <EmailMessageObj:Recipient category="e-mail">
+                                                                <AddrObj:Address_Value>william.abnett@gmail.com</AddrObj:Address_Value>
+                                                            </EmailMessageObj:Recipient>
+                                                        </EmailMessageObj:To>
+                                                        <EmailMessageObj:From category="e-mail">
+                                                            <AddrObj:Address_Value>wmorrison89@gmail.com</AddrObj:Address_Value>
+                                                        </EmailMessageObj:From>
+                                                        <EmailMessageObj:Subject>Iran's Oil and Nuclear Situation</EmailMessageObj:Subject>
+                                                        <EmailMessageObj:Date datatype="dateTime">2012-03-02T07:42:24Z</EmailMessageObj:Date>
+                                                    </EmailMessageObj:Header>
+                                                    <EmailMessageObj:Raw_Header datatype="string"><![CDATA[
+                                            Return-Path: <wmorrison89@gmail.com>
+                    Received-SPF: pass (google.com: domain of wmorrison89@gmail.com designates
+                    10.236.185.4 as permitted sender) client-ip=10.236.185.4;
+                    Authentication-Results: mr.google.com; spf=pass (google.com: domain of
+                    wmorrison89@gmail.com designates 10.236.185.4 as permitted sender)
+                    smtp.mail=wmorrison89@gmail.com; dkim=pass header.i=wmorrison89@gmail.com
+                    Received: from mr.google.com ([10.236.185.4]) by 10.236.185.4 with SMTP
+                    id t4mr5301660yhm.129.1330692273662 (num_hops = 1); Fri, 02 Mar 2012
+                    04:44:33 -0800 (PST)
+                    MIME-Version: 1.0
+                    Received: by 10.236.185.4 with SMTP id t4mr4236541yhm.129.1330692265380;
+                    Fri,
+                    02 Mar 2012 04:44:25 -0800 (PST)
+                    Received: by 10.147.35.14 with HTTP; Fri, 2 Mar 2012 04:44:24 -0800 (PST)
+                    In-Reply-To:
+                    <CADY6HTa-jmaqmtVyyT-nLz6reztNjcs-617wL4bt9YBOGu+h4w@mail.gmail.com>
+                    References:
+                    <CADY6HTa-jmaqmtVyyT-nLz6reztNjcs-617wL4bt9YBOGu+h4w@mail.gmail.com>
+                    Date: Fri, 2 Mar 2012 07:44:24 -0500
+                    Message-ID:
+                    <CADY6HTZ6oopY5v6WkYU81YcSQw3X124CK_Fx4jhnhUiU3Y9z6A@mail.gmail.com>
+                    Subject: Iran's Oil and Nuclear Situation
+                    From: william abnett <wmorrison89@gmail.com>
+                    To: william.abnett <william.abnett@gmail.com>
+                    Content-Type: multipart/mixed; boundary="20cf303f67fac8928804ba41efd5"
+                                        ]]></EmailMessageObj:Raw_Header>
+                                                    <EmailMessageObj:Attachments>
+                                                        <EmailMessageObj:File object_reference="cybox:guid-49d31c13-8d7b-4528-b8d6-ce8ed0d43ad7"/>
+                                                    </EmailMessageObj:Attachments>
+                                                </cybox:Properties>
+                                                <cybox:Association_Type xsi:type="cyboxVocabs:ActionObjectAssociationTypeVocab-1.0">Returned</cybox:Association_Type>
+                                            </cybox:Associated_Object>
+                                        </cybox:Associated_Objects>
+                                    </cybox:Action>
+                                </cybox:Actions>
+                            </cybox:Event>
+                        </indicator:Observable>
+                        <indicator:Observable id="example:Obervable-35f04c28-5fd2-4d72-8aae-2ad04ee1811f">
+                            <!-- Open Iran-Oil corrupted .doc file-->
+                            <cybox:Event>
+                                <cybox:Type xsi:type="cyboxVocabs:EventTypeVocab-1.0">File Ops (CRUD)</cybox:Type>
+                                <cybox:Description>Open Iran-Oil corrupted .doc file.</cybox:Description>
+                                <cybox:Actions>
+                                    <cybox:Action>
+                                        <cybox:Type xsi:type="cyboxVocabs:ActionTypeVocab-1.0">Open</cybox:Type>
+                                        <cybox:Associated_Objects>
+                                            <cybox:Associated_Object id="example:Object-49d31c13-8d7b-4528-b8d6-ce8ed0d43ad7">
+                                                <cybox:Description>
+                                                    The word document contains flash, which downloads a
+                                                    corrupted mp4 file. The mp4 file itself is not anything special
+                                                    but an 0C filled (22kb) mp4 file with a valid mp4
+                                                    header.
+                                                </cybox:Description>
+                                                <cybox:Properties xsi:type="FileObj:FileObjectType">
+                                                    <FileObj:File_Name>Iran's Oil and Nuclear Situation.doc</FileObj:File_Name>
+                                                    <FileObj:Size_In_Bytes>106604</FileObj:Size_In_Bytes>
+                                                    <FileObj:Hashes>
+                                                        <cyboxCommon:Hash>
+                                                            <cyboxCommon:Type>MD5</cyboxCommon:Type>
+                                                            <cyboxCommon:Simple_Hash_Value condition="Equals">E92A4FC283EB2802AD6D0E24C7FCC857</cyboxCommon:Simple_Hash_Value>
+                                                        </cyboxCommon:Hash>
+                                                    </FileObj:Hashes>
+                                                </cybox:Properties>
+                                                <cybox:Association_Type xsi:type="cyboxVocabs:ActionObjectAssociationTypeVocab-1.0">Affected</cybox:Association_Type>
+                                            </cybox:Associated_Object>
+                                        </cybox:Associated_Objects>
+                                    </cybox:Action>
+                                </cybox:Actions>
+                            </cybox:Event>
+                        </indicator:Observable>
+                        <indicator:Observable id="example:Observable-f005fbc6-7427-43ea-8e1e-9a341836f76b">
+                            <!-- Download Iran-Oil invalid .mp4 downloader file-->
+                            <cybox:Event>
+                                <cybox:Type xsi:type="cyboxVocabs:EventTypeVocab-1.0">File Ops (CRUD)</cybox:Type>
+                                <cybox:Description>Download Iran-Oil invalid .mp4 downloader file.</cybox:Description>
+                                <cybox:Actions>
+                                    <cybox:Action>
+                                        <cybox:Type xsi:type="cyboxVocabs:ActionTypeVocab-1.0">Download</cybox:Type>
+                                        <cybox:Associated_Objects>
+                                            <cybox:Associated_Object idref="example:Object-49d31c13-8d7b-4528-b8d6-ce8ed0d43ad7">
+                                                <cybox:Association_Type xsi:type="cyboxVocabs:ActionObjectAssociationTypeVocab-1.0">Initiating</cybox:Association_Type>
+                                            </cybox:Associated_Object>
+                                            <cybox:Associated_Object id="example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa">
+                                                <!-- Iran-Oil invalid .mp4 downloader file-->
+                                                <cybox:Description>
+                                                    This mp4 file causes memory corruption and code
+                                                    execution via heap-spraying code injection.
+                                                </cybox:Description>
+                                                <cybox:Properties xsi:type="FileObj:FileObjectType">
+                                                    <FileObj:File_Name>test.mp4</FileObj:File_Name>
+                                                    <FileObj:Size_In_Bytes>22384</FileObj:Size_In_Bytes>
+                                                    <FileObj:Hashes>
+                                                        <cyboxCommon:Hash>
+                                                            <cyboxCommon:Type>MD5</cyboxCommon:Type>
+                                                            <cyboxCommon:Simple_Hash_Value condition="Equals">8933598C8B1FA5E493497B11C48DA4F2</cyboxCommon:Simple_Hash_Value>
+                                                        </cyboxCommon:Hash>
+                                                    </FileObj:Hashes>
+                                                </cybox:Properties>
+                                                <cybox:Related_Objects>
+                                                    <cybox:Related_Object idref="example:Object-49d31c13-8d7b-4528-b8d6-ce8ed0d43ad7">
+                                                        <cybox:Relationship xsi:type="cyboxVocabs:ObjectRelationshipVocab-1.0">Downloaded_By</cybox:Relationship>
+                                                    </cybox:Related_Object>
+                                                    <cybox:Related_Object idref="example:Object-61041b8b-0c15-48a0-ac5f-b49488788010">
+                                                        <cybox:Relationship xsi:type="cyboxVocabs:ObjectRelationshipVocab-1.0">Downloaded_From</cybox:Relationship>
+                                                    </cybox:Related_Object>
+                                                </cybox:Related_Objects>
+                                                <cybox:Association_Type xsi:type="cyboxVocabs:ActionObjectAssociationTypeVocab-1.0">Affected</cybox:Association_Type>
+                                            </cybox:Associated_Object>
+                                            <cybox:Associated_Object id="example:Object-61041b8b-0c15-48a0-ac5f-b49488788010">
+                                                <!-- URL from which malicious .mp4 file was downloaded-->
+                                                <cybox:Properties xsi:type="URIObj:URIObjectType" type="URL">
+                                                    <URIObj:Value condition="Equals">http://208.115.230.76/test.mp4</URIObj:Value>
+                                                </cybox:Properties>
+                                                <cybox:Association_Type xsi:type="cyboxVocabs:ActionObjectAssociationTypeVocab-1.0">Utilized</cybox:Association_Type>
+                                            </cybox:Associated_Object>
+                                        </cybox:Associated_Objects>
+                                    </cybox:Action>
+                                </cybox:Actions>
+                            </cybox:Event>
+                        </indicator:Observable>
+                        <indicator:Observable id="example:Observable-210f18f3-3874-4f9a-861d-71b328be90c6">
+                            <!-- Create Iran-Oil .exe Trojan file-->
+                            <cybox:Event>
+                                <cybox:Type xsi:type="cyboxVocabs:EventTypeVocab-1.0">File Ops (CRUD)</cybox:Type>
+                                <cybox:Description>Create Iran-Oil .exe Trojan file.</cybox:Description>
+                                <cybox:Actions>
+                                    <cybox:Action>
+                                        <cybox:Type xsi:type="cyboxVocabs:ActionTypeVocab-1.0">Create</cybox:Type>
+                                        <cybox:Associated_Objects>
+                                            <cybox:Associated_Object idref="example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa">
+                                                <cybox:Association_Type xsi:type="cyboxVocabs:ActionObjectAssociationTypeVocab-1.0">Initiating</cybox:Association_Type>
+                                            </cybox:Associated_Object>
+                                            <cybox:Associated_Object id="example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c">
+                                                <cybox:Description>
+                                                    The file (us.exe MD5: FD1BE09E499E8E380424B3835FC973A8
+                                                    4861440 bytes) is created in the logged in user %Temp%
+                                                    directory. The size of the embedded file is 22.5 KB (23040
+                                                    bytes) and the size of the created us.exe is 4.63MB. It is an
+                                                    odd discrepancy until you look at the file and it looks like the
+                                                    code is repeated over and over - 211 times. The file resource
+                                                    section indicates the file is meant to look like a java updater,
+                                                    which is always larger than 22.5KB and that would explain all
+                                                    this padding, which is done at the time when the file is being
+                                                    written to the disk.
+                                                </cybox:Description>
+                                                <cybox:Properties xsi:type="FileObj:FileObjectType">
+                                                    <FileObj:File_Name>us.exe</FileObj:File_Name>
+                                                    <FileObj:File_Path>%Temp%</FileObj:File_Path>
+                                                    <FileObj:Size_In_Bytes>4861440</FileObj:Size_In_Bytes>
+                                                    <FileObj:Hashes>
+                                                        <cyboxCommon:Hash>
+                                                            <cyboxCommon:Type>MD5</cyboxCommon:Type>
+                                                            <cyboxCommon:Simple_Hash_Value condition="Equals">FD1BE09E499E8E380424B3835FC973A8</cyboxCommon:Simple_Hash_Value>
+                                                        </cyboxCommon:Hash>
+                                                    </FileObj:Hashes>
+                                                </cybox:Properties>
+                                                <cybox:Related_Objects>
+                                                    <cybox:Related_Object idref="example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa">
+                                                        <cybox:Relationship xsi:type="cyboxVocabs:ObjectRelationshipVocab-1.0">Created_By</cybox:Relationship>
+                                                    </cybox:Related_Object>
+                                                    <!-- The trojan connects to the following set of URLs/IPs for C&C -->
+                                                    <cybox:Related_Object idref="example:Object-41b220d8-4c45-48de-9d08-30d661b2dc8e">
+                                                        <cybox:Relationship xsi:type="cyboxVocabs:ObjectRelationshipVocab-1.0">Connected_To</cybox:Relationship>
+                                                    </cybox:Related_Object>
+                                                    <cybox:Related_Object idref="example:Object-61aa225b-90ef-415c-8bbd-a17282e457c9">
+                                                        <cybox:Relationship xsi:type="cyboxVocabs:ObjectRelationshipVocab-1.0">Connected_To</cybox:Relationship>
+                                                    </cybox:Related_Object>
+                                                    <cybox:Related_Object idref="example:Object-568db11e-39ee-43d7-83d8-032bdec3801a">
+                                                        <cybox:Relationship xsi:type="cyboxVocabs:ObjectRelationshipVocab-1.0">Connected_To</cybox:Relationship>
+                                                    </cybox:Related_Object>
+                                                    <cybox:Related_Object idref="example:Object-80bea4d1-0e70-4a03-a54f-e40373bf94f1">
+                                                        <cybox:Relationship xsi:type="cyboxVocabs:ObjectRelationshipVocab-1.0">Connected_To</cybox:Relationship>
+                                                    </cybox:Related_Object>
+                                                    <cybox:Related_Object idref="example:Object-af7cb3b6-d70b-4b3b-b24f-7cfad739710f">
+                                                        <cybox:Relationship xsi:type="cyboxVocabs:ObjectRelationshipVocab-1.0">Connected_To</cybox:Relationship>
+                                                    </cybox:Related_Object>
+                                                    <cybox:Related_Object idref="example:guid-5ceb9d54-24e2-4627-948d-6b92ac81962a">
+                                                        <cybox:Relationship xsi:type="cyboxVocabs:ObjectRelationshipVocab-1.0">Connected_To</cybox:Relationship>
+                                                    </cybox:Related_Object>
+                                                </cybox:Related_Objects>
+                                                <cybox:Association_Type xsi:type="cyboxVocabs:ActionObjectAssociationTypeVocab-1.0">Affected</cybox:Association_Type>
+                                            </cybox:Associated_Object>
+                                        </cybox:Associated_Objects>
+                                    </cybox:Action>
+                                </cybox:Actions>
+                            </cybox:Event>
+                        </indicator:Observable>
+
+                    </stix:Indicator>
+                    <stix:Indicator id="TEST2:indicator-f205f08f-818b-4670-8491-45fad9e37ee4" version="2.0" xsi:type="indicator:IndicatorType">
+                        <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.0">Malware Artifacts</indicator:Type>
+                        <indicator:Description>Test Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!! Test Malwawre Artifact Information!!!! </indicator:Description>
+                        <indicator:Observable id="example:Observable-b650c988-aac7-45ff-967d-9f1e5fc66161">
+                            <!-- Execute Iran-Oil .exe Trojan file-->
+                            <cybox:Event>
+                                <cybox:Type xsi:type="cyboxVocabs:EventTypeVocab-1.0">File Ops (CRUD)</cybox:Type>
+                                <cybox:Description>Execute Iran-Oil .exe Trojan file.</cybox:Description>
+                                <cybox:Actions>
+                                    <cybox:Action>
+                                        <cybox:Type xsi:type="cyboxVocabs:ActionTypeVocab-1.0">Execute</cybox:Type>
+                                        <cybox:Associated_Objects>
+                                            <cybox:Associated_Object idref="example:Object-8b463e0d-cc16-4036-950e-5eeb09bc51aa">
+                                                <cybox:Association_Type xsi:type="cyboxVocabs:ActionObjectAssociationTypeVocab-1.0">Initiating</cybox:Association_Type>
+                                            </cybox:Associated_Object>
+                                            <cybox:Associated_Object idref="example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c">
+                                                <cybox:Association_Type xsi:type="cyboxVocabs:ActionObjectAssociationTypeVocab-1.0">Affected</cybox:Association_Type>
+                                            </cybox:Associated_Object>
+                                        </cybox:Associated_Objects>
+                                    </cybox:Action>
+                                </cybox:Actions>
+                            </cybox:Event>
+                        </indicator:Observable>
+                        <indicator:Observable id="example:Observable-dee72b3e-82fb-4319-bfcc-007e3cf930e8">
+                            <!-- Iran-Oil core embedded .exe Trojan file-->
+                            <cybox:Object id="example:Object-bed1ff22-08e8-4e04-b7ac-908b5271176f">
+                                <cybox:Properties xsi:type="FileObj:FileObjectType">
+                                    <FileObj:File_Name>us-embedded.exe</FileObj:File_Name>
+                                    <FileObj:Size_In_Bytes>23040</FileObj:Size_In_Bytes>
+                                    <FileObj:Hashes>
+                                        <cyboxCommon:Hash>
+                                            <cyboxCommon:Type>MD5</cyboxCommon:Type>
+                                            <cyboxCommon:Simple_Hash_Value condition="Equals">CB3DCDE34FD9FF0E19381D99B02F9692</cyboxCommon:Simple_Hash_Value>
+                                        </cyboxCommon:Hash>
+                                    </FileObj:Hashes>
+                                </cybox:Properties>
+                                <cybox:Related_Objects>
+                                    <cybox:Related_Object idref="example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c">
+                                        <cybox:Relationship xsi:type="cyboxVocabs:ObjectRelationshipVocab-1.0">Contained_Within</cybox:Relationship>
+                                    </cybox:Related_Object>
+                                </cybox:Related_Objects>
+                            </cybox:Object>
+                        </indicator:Observable>
+                        <indicator:Observable id="example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f">
+                            <!-- Trojan .exe file connects out to C&C URLs/IPs-->
+                            <cybox:Event>
+                                <cybox:Type xsi:type="cyboxVocabs:EventTypeVocab-1.0">App Layer Traffic</cybox:Type>
+                                <cybox:Description>Trojan .exe file connects out to C2 URLs/IPs.</cybox:Description>
+                                <cybox:Actions>
+                                    <cybox:Action>
+                                        <cybox:Type xsi:type="cyboxVocabs:ActionTypeVocab-1.0">Connect</cybox:Type>
+                                        <cybox:Associated_Objects>
+                                            <cybox:Associated_Object idref="example:Object-b7e0bc39-f519-4878-8fb0-5902554efe1c">
+                                                <cybox:Association_Type xsi:type="cyboxVocabs:ActionObjectAssociationTypeVocab-1.0">Initiating</cybox:Association_Type>
+                                            </cybox:Associated_Object>
+                                            <cybox:Associated_Object idref="example:Object-41b220d8-4c45-48de-9d08-30d661b2dc8e">
+                                                <cybox:Association_Type xsi:type="cyboxVocabs:ActionObjectAssociationTypeVocab-1.0">Utilized</cybox:Association_Type>
+                                            </cybox:Associated_Object>
+                                            <cybox:Associated_Object idref="example:Object-61aa225b-90ef-415c-8bbd-a17282e457c9">
+                                                <cybox:Association_Type xsi:type="cyboxVocabs:ActionObjectAssociationTypeVocab-1.0">Utilized</cybox:Association_Type>
+                                            </cybox:Associated_Object>
+                                            <cybox:Associated_Object idref="example:Object-568db11e-39ee-43d7-83d8-032bdec3801a">
+                                                <cybox:Association_Type xsi:type="cyboxVocabs:ActionObjectAssociationTypeVocab-1.0">Utilized</cybox:Association_Type>
+                                            </cybox:Associated_Object>
+                                            <cybox:Associated_Object idref="example:Object-80bea4d1-0e70-4a03-a54f-e40373bf94f1">
+                                                <cybox:Association_Type xsi:type="cyboxVocabs:ActionObjectAssociationTypeVocab-1.0">Utilized</cybox:Association_Type>
+                                            </cybox:Associated_Object>
+                                            <cybox:Associated_Object idref="example:Object-af7cb3b6-d70b-4b3b-b24f-7cfad739710f">
+                                                <cybox:Association_Type xsi:type="cyboxVocabs:ActionObjectAssociationTypeVocab-1.0">Utilized</cybox:Association_Type>
+                                            </cybox:Associated_Object>
+                                            <cybox:Associated_Object idref="example:Object-5ceb9d54-24e2-4627-948d-6b92ac81962a">
+                                                <cybox:Association_Type xsi:type="cyboxVocabs:ActionObjectAssociationTypeVocab-1.0">Utilized</cybox:Association_Type>
+                                            </cybox:Associated_Object>
+                                        </cybox:Associated_Objects>
+                                    </cybox:Action>
+                                </cybox:Actions>
+                            </cybox:Event>
+                        </indicator:Observable>
+                        <!-- The next six Observables represent the 3 different URL/IP pairs of C&C servers that the trojan communicates with-->
+                        <indicator:Observable id="example:Observable-066cef51-c886-432e-9a22-a17f57f3f3f2">
+                            <!-- One of three Command and Control URLs-->
+                            <cybox:Object id="example:Object-41b220d8-4c45-48de-9d08-30d661b2dc8e">
+                                <cybox:Properties xsi:type="URIObj:URIObjectType">
+                                    <URIObj:Value condition="Equals">www.documents.myPicture.info</URIObj:Value>
+                                </cybox:Properties>
+                                <cybox:Related_Objects>
+                                    <cybox:Related_Object idref="example:Object-61aa225b-90ef-415c-8bbd-a17282e457c9">
+                                        <cybox:Relationship xsi:type="cyboxVocabs:ObjectRelationshipVocab-1.0">Resolved_To</cybox:Relationship>
+                                    </cybox:Related_Object>
+                                </cybox:Related_Objects>
+                            </cybox:Object>
+                        </indicator:Observable>
+                        <indicator:Observable id="example:Observable-4e05804c-f552-44e1-9793-ff4bb7f88f9c">
+                            <!-- One of three Command and Control IPs-->
+                            <cybox:Object id="example:Object-61aa225b-90ef-415c-8bbd-a17282e457c9">
+                                <cybox:Properties xsi:type="AddrObj:AddressObjectType" category="ipv4-addr">
+                                    <AddrObj:Address_Value condition="Equals">199.192.156.134</AddrObj:Address_Value>
+                                </cybox:Properties>
+                            </cybox:Object>
+                        </indicator:Observable>
+                        <indicator:Observable id="example:Observable-75ce59ad-1f01-4eae-9ecc-0b22c4c24ce7">
+                            <!-- One of three Command and Control URLs-->
+                            <cybox:Object id="example:Object-568db11e-39ee-43d7-83d8-032bdec3801a">
+                                <cybox:Properties xsi:type="URIObj:URIObjectType" type="URL">
+                                    <URIObj:Value condition="Equals">documents.myPicture.info</URIObj:Value>
+                                </cybox:Properties>
+                                <cybox:Related_Objects>
+                                    <cybox:Related_Object idref="example:Object-80bea4d1-0e70-4a03-a54f-e40373bf94f1">
+                                        <cybox:Relationship xsi:type="cyboxVocabs:ObjectRelationshipVocab-1.0">Resolved_To</cybox:Relationship>
+                                    </cybox:Related_Object>
+                                </cybox:Related_Objects>
+                            </cybox:Object>
+                    
+                        </indicator:Observable>
+                    </stix:Indicator>
+                    <stix:Indicator id="TEST3:indicator-f205f08f-818b-4670-8491-45fad9e37ee4" version="2.0" xsi:type="indicator:IndicatorType">
+                        <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.0">Domain Watchlist</indicator:Type>
+                        <indicator:Description>Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!! Domain Watchlist Information!!! </indicator:Description>
+                        <indicator:Observable id="example:Observable-1ea53b14-8fe9-467b-a298-62d9684e797d">
+                            <!-- One of three Command and Control IPs-->
+                            <cybox:Object id="example:Object-80bea4d1-0e70-4a03-a54f-e40373bf94f1">
+                                <cybox:Properties xsi:type="AddrObj:AddressObjectType" category="ipv4-addr">
+                                    <AddrObj:Address_Value condition="Equals">199.192.156.134</AddrObj:Address_Value>
+                                </cybox:Properties>
+                            </cybox:Object>
+                        </indicator:Observable>
+                        <indicator:Observable id="example:Observable-f6c8ee75-ee7e-4490-bd5d-0661d0db7264">
+                            <!-- One of three Command and Control URLs-->
+                            <cybox:Object id="example:Object-af7cb3b6-d70b-4b3b-b24f-7cfad739710f">
+                                <cybox:Properties xsi:type="URIObj:URIObjectType" type="URL">
+                                    <URIObj:Value condition="Equals">ftp.documents.myPicture.info</URIObj:Value>
+                                </cybox:Properties>
+                                <cybox:Related_Objects>
+                                    <cybox:Related_Object idref="example:Object-5ceb9d54-24e2-4627-948d-6b92ac81962a">
+                                        <cybox:Relationship xsi:type="cyboxVocabs:ObjectRelationshipVocab-1.0">Resolved_To</cybox:Relationship>
+                                    </cybox:Related_Object>
+                                </cybox:Related_Objects>
+                            </cybox:Object>
+                        </indicator:Observable>
+                        
+                        
+                        <indicator:Observable id="example:Observable-c78c0a83-6d14-45f8-827f-f758f0cd11ea">
+                            <!-- One of three Command and Control IPs-->
+                            <cybox:Object id="example:Object-5ceb9d54-24e2-4627-948d-6b92ac81962a">
+                                <cybox:Properties xsi:type="AddrObj:AddressObjectType" category="ipv4-addr">
+                                    <AddrObj:Address_Value condition="Equals">199.192.156.134</AddrObj:Address_Value>
+                                </cybox:Properties>
+                            </cybox:Object>
+                        </indicator:Observable>
+                    
+                    
+                        <indicator:Observable id="example:Observable-47d6a950-884d-46b5-9938-ac5555065a81">
+                            <!-- This composed observable defines a pattern that is true if the receive email event occurs AND the create malicious .doc file event occurs AND the download the downloader .mp4 file event occurs AND the create trojan .exe file event occurs AND the execute trojan .exe file event occurs AND the connect to all three of the C&C URLs/IPs event occurs-->
+                            <!-- This yields a very tight filter that will have very low false positives but could miss almost any variation of the attack elements-->
+                            <indicator:Observable_Composition operator="AND">
+                                <!-- Receive "Iran-Oil" attack campaign email message -->
+                                <indicator:Observable idref="example:Observable-1a937ec2-90ab-4e0e-a37c-db9b2e66a58e"/>
+                                <!-- Open Iran-Oil corrupted .doc file-->
+                                <indicator:Observable idref="example:Observable-35f04c28-5fd2-4d72-8aae-2ad04ee1811f"/>
+                                <!-- Download Iran-Oil invalid .mp4 downloader file-->
+                                <indicator:Observable idref="example:Observable-f005fbc6-7427-43ea-8e1e-9a341836f76b"/>
+                                <!-- Create Iran-Oil .exe Trojan file-->
+                                <indicator:Observable idref="example:Observable-210f18f3-3874-4f9a-861d-71b328be90c6"/>
+                                <!-- Execute Iran-Oil .exe Trojan file-->
+                                <indicator:Observable idref="example:Observable-b650c988-aac7-45ff-967d-9f1e5fc66161"/>
+                                <!-- Trojan .exe file connects out to C&C URLs/IPs-->
+                                <indicator:Observable idref="example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f"/>
+                            </indicator:Observable_Composition>
+                        </indicator:Observable>
+                    
+                        <indicator:Observable id="example:Observable-80594430-7567-4402-88a4-05d556b21884">
+                            <!-- This composed observable defines a pattern that is true if the receive email event occurs OR the create malicious .doc file event occurs OR the download the downloader .mp4 file event occurs OR the create trojan .exe file event occurs OR the execute trojan .exe file event occurs OR the connect to all three of the C&C URLs/IPs event occurs-->
+                            <!-- This yields a very loose filter that could have false positives but could catch numerous potential variations of the attack elements-->
+                            <indicator:Observable_Composition operator="OR">
+                                <!-- Receive "Iran-Oil" attack campaign email message -->
+                                <indicator:Observable idref="example:Observable-1a937ec2-90ab-4e0e-a37c-db9b2e66a58e"/>
+                                <!-- Open Iran-Oil corrupted .doc file-->
+                                <indicator:Observable idref="example:Observable-35f04c28-5fd2-4d72-8aae-2ad04ee1811f"/>
+                                <!-- Download Iran-Oil invalid .mp4 downloader file-->
+                                <indicator:Observable idref="example:guid-f005fbc6-7427-43ea-8e1e-9a341836f76b"/>
+                                <!-- Create Iran-Oil .exe Trojan file-->
+                                <indicator:Observable idref="example:Observable-210f18f3-3874-4f9a-861d-71b328be90c6"/>
+                                <!-- Execute Iran-Oil .exe Trojan file-->
+                                <indicator:Observable idref="example:Observable-b650c988-aac7-45ff-967d-9f1e5fc66161"/>
+                                <!-- Trojan .exe file connects out to C&C URLs/IPs-->
+                                <indicator:Observable idref="example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f"/>
+                            </indicator:Observable_Composition>
+                        </indicator:Observable>
+                    
+                        <indicator:Observable id="example:Observable-7d932074-fded-4056-870e-dd51980501d4">
+                            <!-- This composed observable defines a pattern that is true if (the receive email event occurs AND the create malicious .doc file event occurs) OR (the download the downloader .mp4 file event occurs AND the create trojan .exe file event occurs AND the execute trojan .exe file event occurs) OR the connect to all three of the C&C URLs/IPs event occurs-->
+                            <indicator:Observable_Composition operator="OR">
+                                <indicator:Observable>
+                                    <indicator:Observable_Composition operator="AND">
+                                        <!-- Receive "Iran-Oil" attack campaign email message -->
+                                        <indicator:Observable idref="example:Observable-1a937ec2-90ab-4e0e-a37c-db9b2e66a58e"/>
+                                        <!-- Open Iran-Oil corrupted .doc file-->
+                                        <indicator:Observable idref="example:Observable-35f04c28-5fd2-4d72-8aae-2ad04ee1811f"/>
+                                    </indicator:Observable_Composition>
+                                </indicator:Observable>
+                                <indicator:Observable>
+                                    <indicator:Observable_Composition operator="AND">
+                                        <!-- Download Iran-Oil invalid .mp4 downloader file-->
+                                        <indicator:Observable idref="example:Observable-f005fbc6-7427-43ea-8e1e-9a341836f76b"/>
+                                        <!-- Create Iran-Oil .exe Trojan file-->
+                                        <indicator:Observable idref="example:Observable-210f18f3-3874-4f9a-861d-71b328be90c6"/>
+                                        <!-- Execute Iran-Oil .exe Trojan file-->
+                                        <indicator:Observable idref="example:Observable-b650c988-aac7-45ff-967d-9f1e5fc66161"/>
+                                    </indicator:Observable_Composition>
+                                </indicator:Observable>
+                                <!-- Trojan .exe file connects out to C&C URLs/IPs-->
+                                <indicator:Observable idref="example:Observable-a24ff8bc-b534-4616-838b-8bbe260a8e8f"/>
+                            </indicator:Observable_Composition>
+                        </indicator:Observable>
+                    </stix:Indicator>
+                </stix:Indicators>
+            </stix:STIX_Package>
+        </taxii:Content>
+    </taxii:Content_Block> 
+</taxii:Inbox_Message>


### PR DESCRIPTION
When using this XSLT in production, no one will ever use all the inline
HTML drawing capabilities.  They would separate these out into separate
external files.  But I can definitely see why we need it inlined into 1
HTML output file!

In order to accomodate this pull request, I setup a CONFIG area where
we can expand on in the future for future global controls.

The current features are "include_html_body" (which when not true),
will output a "clean template" with just a div wrapping the Cybox
Object.

Also added control for showing your "Cybox summery version header"
(which is now a separated template), which will most certainly not be
needed in a production environment version of this XSLT.

@todo, we need to when in "clean mode" we need to some how be able to
output the outer div without XMLNS.  I am not sure how to clean out the
XML namespaces out of the output when include_html_body is false.  Do
you ikiril01 or other maintainers at Mitre know how to remove XMLNS for
my case where I want a "partial Cybox only" output with no injection of
namespaces into my outer DIV?

Please approve and pull into 2013-06_xslt_stylesheet_sandbox for later
merge with master once it is ready to merge.

Oh, and I also added conditional debug flag in the config variables, so when debugging common problems we can turn on and off for production mode or development XSLT debugging.
